### PR TITLE
fix: compare deployment versions semantically

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.21",
+    "@types/semver": "^7.3.9",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "eslint": "^7.13.0",
@@ -44,5 +45,8 @@
     "prettier": "^2.1.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
+  },
+  "dependencies": {
+    "semver": "^7.3.7"
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
 import { DeploymentFilter, SingletonDeployment } from "./types"
+import semverSatisfies from "semver/functions/satisfies";
 
 export const findDeployment = (criteria: DeploymentFilter, deployments: SingletonDeployment[]): SingletonDeployment | undefined =>
-    deployments.find((deployment) => {
-        if (criteria.version && deployment.version !== criteria.version) return false
+  deployments.find((deployment) => {
+        if (criteria.version && !semverSatisfies(deployment.version, criteria.version)) return false
         if (criteria.released && deployment.released != criteria.released) return false
         if (criteria.network && !deployment.networkAddresses[criteria.network]) return false
         return true

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
   integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
 
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@typescript-eslint/eslint-plugin@^4.7.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
@@ -1311,6 +1316,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## Overview

This compares deployment versions with `semver` instead of by strict comparison, therefore allowing for metadata, i.e.

```ts
'1.3.0' === '1.3.0+L2' // false
semverSatisfies('1.3.0', '1.3.0+L2') // true
```