### PR TITLE
fix: pamp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-deployments",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Collection of Safe singleton deployments",
   "homepage": "https://github.com/gnosis/safe-deployments/",
   "license": "MIT",


### PR DESCRIPTION
## Overview

In order to deploy https://github.com/safe-global/safe-deployments/pull/89, the version needed to be bumped.