### PR TITLE
Add ProxyFactory v1.0.0

### DIFF
--- a/src/assets/v1.0.0/proxy_factory.json
+++ b/src/assets/v1.0.0/proxy_factory.json
@@ -1,0 +1,105 @@
+{
+  "defaultAddress": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
+  "released": true,
+  "contractName": "ProxyFactory",
+  "version": "1.0.0",
+  "networkAddresses": {
+    "1": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
+    "4": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
+    "5": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
+    "42": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
+    "100": "0x12302fE9c02ff50939BaAaaf415fc226C078613C"
+  },
+  "abi": [
+    {
+      "constant":false,
+      "inputs":[
+        {
+          "name":"_mastercopy",
+          "type":"address"
+        },
+        {
+          "name":"initializer",
+          "type":"bytes"
+        },
+        {
+          "name":"saltNonce",
+          "type":"uint256"
+        }
+      ],
+      "name":"createProxyWithNonce",
+      "outputs":[
+        {
+          "name":"proxy",
+          "type":"address"
+        }
+      ],
+      "payable":false,
+      "stateMutability":"nonpayable",
+      "type":"function"
+    },
+    {
+      "constant":true,
+      "inputs":[],
+      "name":"proxyCreationCode",
+      "outputs":[
+        {
+          "name":"",
+          "type":"bytes"
+        }
+      ],
+      "payable":false,
+      "stateMutability":"pure",
+      "type":"function"
+    },
+    {
+      "constant":false,
+      "inputs":[
+        {
+          "name":"masterCopy",
+          "type":"address"
+        },
+        {
+          "name":"data",
+          "type":"bytes"
+        }
+      ],
+      "name":"createProxy",
+      "outputs":[
+        {
+          "name":"proxy",
+          "type":"address"
+        }
+      ],
+      "payable":false,
+      "stateMutability":"nonpayable",
+      "type":"function"
+    },
+    {
+      "constant":true,
+      "inputs":[],
+      "name":"proxyRuntimeCode",
+      "outputs":[
+        {
+          "name":"",
+          "type":"bytes"
+        }
+      ],
+      "payable":false,
+      "stateMutability":"pure",
+      "type":"function"
+    },
+    {
+      "anonymous":false,
+      "inputs":[
+        {
+          "indexed":false,
+          "name":"proxy",
+          "type":"address"
+        }
+      ],
+      "name":"ProxyCreation",
+      "type":"event"
+    }
+  ]
+}

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -1,3 +1,4 @@
+import ProxyFactory100 from './assets/v1.0.0/proxy_factory.json'
 import ProxyFactory111 from './assets/v1.1.1/proxy_factory.json'
 import ProxyFactory130 from './assets/v1.3.0/proxy_factory.json'
 import { DeploymentFilter, SingletonDeployment } from './types'
@@ -5,7 +6,7 @@ import { findDeployment } from './utils'
 
 // This is a sorted array (newest to oldest)
 const factoryDeployments: SingletonDeployment[] = [
-    ProxyFactory130, ProxyFactory111
+    ProxyFactory130, ProxyFactory111, ProxyFactory100
 ]
 
 export const getProxyFactoryDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {


### PR DESCRIPTION
This PR adds the ProxyFactory v1.0.0 contract.

The Safe Core SDK will add support for Safe contracts v1.0.0 and this asset was missing.

Check: https://github.com/safe-global/safe-deployments/issues/150