### PR TITLE
Add MultiSend v1.0.0

### DIFF
--- a/src/__tests__/libs.test.ts
+++ b/src/__tests__/libs.test.ts
@@ -1,4 +1,5 @@
 import CreateCall130 from '../assets/v1.3.0/create_call.json';
+import MultiSend100 from '../assets/v1.0.0/multi_send.json';
 import MultiSend111 from '../assets/v1.1.1/multi_send.json';
 import MultiSend130 from '../assets/v1.3.0/multi_send.json';
 import MultiSendCallOnly130 from '../assets/v1.3.0/multi_send_call_only.json';
@@ -15,7 +16,9 @@ describe('libs.ts', () => {
     it('should find the preferred deployment first', () => {
       const result = getMultiSendDeployment();
       expect(result).toBe(MultiSend130);
-      expect(result).not.toBe(MultiSend111);
+      [MultiSend111, MultiSend100].forEach((version) => {
+        expect(result).not.toBe(version);
+      });
     });
   });
   describe('getMultiSendCallOnlyDeployment', () => {

--- a/src/assets/v1.0.0/multi_send.json
+++ b/src/assets/v1.0.0/multi_send.json
@@ -1,0 +1,29 @@
+{
+  "defaultAddress": "0xD4B7B161E4779629C2717385114Bf78D612aEa72",
+  "released": true,
+  "contractName": "MultiSend",
+  "version": "1.0.0",
+  "networkAddresses": {
+    "1": "0xD4B7B161E4779629C2717385114Bf78D612aEa72",
+    "4": "0xD4B7B161E4779629C2717385114Bf78D612aEa72",
+    "5": "0xD4B7B161E4779629C2717385114Bf78D612aEa72",
+    "42": "0xD4B7B161E4779629C2717385114Bf78D612aEa72",
+    "100": "0xD4B7B161E4779629C2717385114Bf78D612aEa72"
+  },
+  "abi": [
+    {
+      "constant":false,
+      "inputs":[
+        {
+          "name":"transactions",
+          "type":"bytes"
+        }
+      ],
+      "name":"multiSend",
+      "outputs":[],
+      "payable":false,
+      "stateMutability":"nonpayable",
+      "type":"function"
+    }
+  ]
+}

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -1,4 +1,5 @@
 import CreateCall130 from './assets/v1.3.0/create_call.json'
+import MultiSend100 from './assets/v1.0.0/multi_send.json'
 import MultiSend111 from './assets/v1.1.1/multi_send.json'
 import MultiSend130 from './assets/v1.3.0/multi_send.json'
 import MultiSendCallOnly130 from './assets/v1.3.0/multi_send_call_only.json'
@@ -8,7 +9,7 @@ import { findDeployment } from './utils'
 
 // This is a sorted array (by preference, currently we use 111 in most cases)
 const multiSendDeployments: SingletonDeployment[] = [
-  MultiSend130, MultiSend111
+  MultiSend130, MultiSend111, MultiSend100
 ]
 
 export const getMultiSendDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {


### PR DESCRIPTION
This PR adds the MultiSend v1.0.0 contract.

The Safe Core SDK will add support for Safe contracts v1.0.0 and this asset was missing.

Check: https://github.com/safe-global/safe-deployments/issues/150