### PR TITLE
Bump version to 1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-deployments",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Collection of Safe singleton deployments",
   "homepage": "https://github.com/gnosis/safe-deployments/",
   "license": "MIT",


### PR DESCRIPTION
## Before merging
Please check if the other existing PRs should be merged and included in this version.
In case new PR's are merged before this one, update the changelog below correspondingly.

## Before releasing
The github release of the version `v1.16.0` does not exist, it only exists in npm. I pushed the corresponding tag, but `v1.16.0` should be released on Github first to respect the right order.


## To be added to the Changelog
Once the tag `v1.17.0` is published and the version is released add the following lines to the changelog, highlighting all the new changes after `v1.16.0`:

```
## What's Changed
* Add Arbitrum Nova by @moisses89 in https://github.com/safe-global/safe-deployments/pull/104
* Add milkomeda algorand testnet by @moisses89 in https://github.com/safe-global/safe-deployments/pull/102
* Add Venidium mainnet by @moisses89 in https://github.com/safe-global/safe-deployments/pull/106
* Add Cloudwalk Testnet by @oscar-gross in https://github.com/safe-global/safe-deployments/pull/107
* Update issue template by @moisses89 in https://github.com/safe-global/safe-deployments/pull/118
* Add ETC's Classic (mainnet) and Mordor (testnet) deployments by @ziogaschr in https://github.com/safe-global/safe-deployments/pull/114
* Add Telos EVM Mainnet by @nick8319 in https://github.com/safe-global/safe-deployments/pull/117
* Add Bobabeam mainnet by @datradito in https://github.com/safe-global/safe-deployments/pull/120
* Add kcc mainnet and testnet by @mhxw in https://github.com/safe-global/safe-deployments/pull/122
* Add rabbit chain by @amankumarp in https://github.com/safe-global/safe-deployments/pull/123
* Add Telos EVM Testnet by @nick8319 in https://github.com/safe-global/safe-deployments/pull/126
* Add Goerli Optimism by @rmeissner in https://github.com/safe-global/safe-deployments/pull/119
* Add Sepolia by @hectorgomezv in https://github.com/safe-global/safe-deployments/pull/131
* Add canto by @akshatcx in https://github.com/safe-global/safe-deployments/pull/135
* Add Kava Mainnet by @noah-ren in https://github.com/safe-global/safe-deployments/pull/137
* Add Fantom Opera by @noah-ren in https://github.com/safe-global/safe-deployments/pull/139
* Add Binance Smart Chain Testnet by @noah-ren in https://github.com/safe-global/safe-deployments/pull/141
* Add Avalanche Fuji Testnet by @noah-ren in https://github.com/safe-global/safe-deployments/pull/143
* Add PublicMint mainNet and testNet by @rafaeltorres-seegno in https://github.com/safe-global/safe-deployments/pull/129
* Add milkomeda algorand mainnet by @pkakelas in https://github.com/safe-global/safe-deployments/pull/132
* Add Kava evm Testnet by @noah-ren in https://github.com/safe-global/safe-deployments/pull/145
* Add the asset ProxyFactory v1.0.0 by @germartinez in https://github.com/safe-global/safe-deployments/pull/151
* Update version to v1.17.0 by @germartinez in https://github.com/safe-global/safe-deployments/pull/153

## New Contributors
* @oscar-gross made their first contribution in https://github.com/safe-global/safe-deployments/pull/107
* @ziogaschr made their first contribution in https://github.com/safe-global/safe-deployments/pull/114
* @nick8319 made their first contribution in https://github.com/safe-global/safe-deployments/pull/117
* @datradito made their first contribution in https://github.com/safe-global/safe-deployments/pull/120
* @mhxw made their first contribution in https://github.com/safe-global/safe-deployments/pull/122
* @amankumarp made their first contribution in https://github.com/safe-global/safe-deployments/pull/123
* @akshatcx made their first contribution in https://github.com/safe-global/safe-deployments/pull/135
* @noah-ren made their first contribution in https://github.com/safe-global/safe-deployments/pull/137
* @rafaeltorres-seegno made their first contribution in https://github.com/safe-global/safe-deployments/pull/129
* @pkakelas made their first contribution in https://github.com/safe-global/safe-deployments/pull/132

**Full Changelog**: https://github.com/safe-global/safe-deployments/compare/v1.16.0...v1.17.0
```