### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-deployments",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Collection of Safe singleton deployments",
   "homepage": "https://github.com/gnosis/safe-deployments/",
   "license": "MIT",


### PR DESCRIPTION
## Description
Increases the version of safe-deployments from `1.17.0` to `1.18.0`
## V1.18.0 changes 
* Add Safe Contract Deployments on Autobahn Network by @mikelohmann in https://github.com/safe-global/safe-deployments/pull/146
* feat: add godwoken mainnet by @Kuzirashi in https://github.com/safe-global/safe-deployments/pull/147
* Add Chiado testnet by @germartinez in https://github.com/safe-global/safe-deployments/pull/158
* Add metis goerli deployments by @t0mcr8se in https://github.com/safe-global/safe-deployments/pull/161
* add xdc blockchain apothem testnet by @gzliudan in https://github.com/safe-global/safe-deployments/pull/166
* add xdc blockchain xinfin mainnet by @gzliudan in https://github.com/safe-global/safe-deployments/pull/167

## New Contributors
* @mikelohmann made their first contribution in https://github.com/safe-global/safe-deployments/pull/146
* @gzliudan made their first contribution in https://github.com/safe-global/safe-deployments/pull/166