### PR TITLE
Feature: Switch v1.4.1 to released

### DIFF
--- a/src/__tests__/factories.test.ts
+++ b/src/__tests__/factories.test.ts
@@ -1,13 +1,13 @@
 import ProxyFactory130 from '../assets/v1.3.0/proxy_factory.json';
-import ProxyFactory111 from '../assets/v1.1.1/proxy_factory.json';
+import ProxyFactory141 from '../assets/v1.4.1/safe_proxy_factory.json';
 import { getProxyFactoryDeployment } from '../factories';
 
 describe('factories.ts', () => {
   describe('getProxyFactoryDeployment', () => {
     it('should find the latest deployment first', () => {
       const result = getProxyFactoryDeployment();
-      expect(result).toBe(ProxyFactory130);
-      expect(result).not.toBe(ProxyFactory111);
+      expect(result).toBe(ProxyFactory141);
+      expect(result).not.toBe(ProxyFactory130);
     });
   });
 });

--- a/src/__tests__/handler.test.ts
+++ b/src/__tests__/handler.test.ts
@@ -1,5 +1,5 @@
 import DefaultCallbackHandler130 from '../assets/v1.1.1/default_callback_handler.json';
-import CompatibilityFallbackHandler from '../assets/v1.3.0/compatibility_fallback_handler.json';
+import CompatibilityFallbackHandler141 from '../assets/v1.4.1/compatibility_fallback_handler.json';
 import {
   getDefaultCallbackHandlerDeployment,
   getCompatibilityFallbackHandlerDeployment,
@@ -17,14 +17,14 @@ describe('handler.ts', () => {
   describe('getCompatibilityFallbackHandlerDeployment', () => {
     it('should find the preferred deployment first', () => {
       const result = getCompatibilityFallbackHandlerDeployment();
-      expect(result).toBe(CompatibilityFallbackHandler);
+      expect(result).toBe(CompatibilityFallbackHandler141);
     });
   });
 
   describe('getFallbackHandlerDeployment', () => {
     it('should find the preferred deployment first', () => {
       const result = getFallbackHandlerDeployment();
-      expect(result).toBe(CompatibilityFallbackHandler);
+      expect(result).toBe(CompatibilityFallbackHandler141);
       expect(result).not.toBe(DefaultCallbackHandler130);
     });
   });

--- a/src/__tests__/libs.test.ts
+++ b/src/__tests__/libs.test.ts
@@ -1,8 +1,8 @@
-import CreateCall130 from '../assets/v1.3.0/create_call.json';
+import CreateCall141 from '../assets/v1.4.1/create_call.json';
 import MultiSend111 from '../assets/v1.1.1/multi_send.json';
-import MultiSend130 from '../assets/v1.3.0/multi_send.json';
-import MultiSendCallOnly130 from '../assets/v1.3.0/multi_send_call_only.json';
-import SignMessageLib130 from '../assets/v1.3.0/sign_message_lib.json';
+import MultiSend141 from '../assets/v1.4.1/multi_send.json';
+import MultiSendCallOnly141 from '../assets/v1.4.1/multi_send_call_only.json';
+import SignMessageLib141 from '../assets/v1.4.1/sign_message_lib.json';
 import {
   getMultiSendDeployment,
   getMultiSendCallOnlyDeployment,
@@ -14,26 +14,26 @@ describe('libs.ts', () => {
   describe('getMultiSendDeployment', () => {
     it('should find the preferred deployment first', () => {
       const result = getMultiSendDeployment();
-      expect(result).toBe(MultiSend130);
+      expect(result).toBe(MultiSend141);
       expect(result).not.toBe(MultiSend111);
     });
   });
   describe('getMultiSendCallOnlyDeployment', () => {
     it('should find the preferred deployment first', () => {
       const result = getMultiSendCallOnlyDeployment();
-      expect(result).toBe(MultiSendCallOnly130);
+      expect(result).toBe(MultiSendCallOnly141);
     });
   });
   describe('getCreateCallDeployment', () => {
     it('should find the preferred deployment first', () => {
       const result = getCreateCallDeployment();
-      expect(result).toBe(CreateCall130);
+      expect(result).toBe(CreateCall141);
     });
   });
   describe('getSignMessageLibDeployment', () => {
     it('should find the preferred deployment first', () => {
       const result = getSignMessageLibDeployment();
-      expect(result).toBe(SignMessageLib130);
+      expect(result).toBe(SignMessageLib141);
     });
   });
 });

--- a/src/__tests__/safes.test.ts
+++ b/src/__tests__/safes.test.ts
@@ -1,4 +1,5 @@
-import GnosisSafeL2130 from '../assets/v1.3.0/gnosis_safe_l2.json';
+import SafeL2141 from '../assets/v1.4.1/safe_l2.json';
+import Safe141 from '../assets/v1.4.1/safe.json';
 import GnosisSafe130 from '../assets/v1.3.0/gnosis_safe.json';
 import GnosisSafe120 from '../assets/v1.2.0/gnosis_safe.json';
 import GnosisSafe111 from '../assets/v1.1.1/gnosis_safe.json';
@@ -12,8 +13,8 @@ describe('safes.ts', () => {
   describe('getSafeSingletonDeployment', () => {
     it('should find the latest deployment first', () => {
       const result = getSafeSingletonDeployment();
-      expect(result).toBe(GnosisSafe130);
-      [GnosisSafe120, GnosisSafe111, GnosisSafe100].forEach((version) => {
+      expect(result).toBe(Safe141);
+      [GnosisSafe130, GnosisSafe120, GnosisSafe111, GnosisSafe100].forEach((version) => {
         expect(result).not.toBe(version);
       });
     });
@@ -21,7 +22,7 @@ describe('safes.ts', () => {
   describe('getSafeL2SingletonDeployment', () => {
     it('should find the latest deployment first', () => {
       const result = getSafeL2SingletonDeployment();
-      expect(result).toBe(GnosisSafeL2130);
+      expect(result).toBe(SafeL2141);
     });
   });
 });

--- a/src/__tests__/utilts.test.ts
+++ b/src/__tests__/utilts.test.ts
@@ -1,3 +1,6 @@
+import SafeL2141 from '../assets/v1.4.1/safe_l2.json';
+import Safe141 from '../assets/v1.4.1/safe.json';
+
 import GnosisSafeL2130 from '../assets/v1.3.0/gnosis_safe_l2.json';
 import GnosisSafe130 from '../assets/v1.3.0/gnosis_safe.json';
 import GnosisSafe120 from '../assets/v1.2.0/gnosis_safe.json';
@@ -98,7 +101,7 @@ describe('utils.ts', () => {
 
       // Chronological deployments
       expect(findDeployment({ released: true }, _safeDeployments)).toBe(
-        GnosisSafe130
+        Safe141
       );
 
       // Reverse chronological deployments
@@ -112,7 +115,7 @@ describe('utils.ts', () => {
 
       // L2 deployments
       expect(findDeployment({ released: true }, _safeL2Deployments)).toBe(
-        GnosisSafeL2130
+        SafeL2141
       );
     });
 
@@ -134,7 +137,7 @@ describe('utils.ts', () => {
 
       // L2 deployments
       expect(findDeployment({ network: '100' }, _safeL2Deployments)).toBe(
-        GnosisSafeL2130
+        SafeL2141
       );
       // Incorrect filter:
       expect(
@@ -290,7 +293,7 @@ describe('utils.ts', () => {
       // L2 deployments
       expect(
         findDeployment({ released: true, network: '100' }, _safeL2Deployments)
-      ).toBe(GnosisSafeL2130);
+      ).toBe(SafeL2141);
       // Incorrect filter:
       expect(
         findDeployment({ released: true, network: '0' }, _safeL2Deployments)

--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-  "released": false,
+  "released": true,
   "contractName": "CompatibilityFallbackHandler",
   "version": "1.4.1",
   "networkAddresses": {

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0x9b35Af71d77eaf8d7e40252370304687390A1A52",
-  "released": false,
+  "released": true,
   "contractName": "CreateCall",
   "version": "1.4.1",
   "networkAddresses": {

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
-  "released": false,
+  "released": true,
   "contractName": "MultiSend",
   "version": "1.4.1",
   "networkAddresses": {

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
-  "released": false,
+  "released": true,
   "contractName": "MultiSendCallOnly",
   "version": "1.4.1",
   "networkAddresses": {

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
-  "released": false,
+  "released": true,
   "contractName": "Safe",
   "version": "1.4.1",
   "networkAddresses": {

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
-  "released": false,
+  "released": true,
   "contractName": "SafeL2",
   "version": "1.4.1",
   "networkAddresses": {

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -2,7 +2,7 @@
   "defaultAddress": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
   "contractName": "SafeProxyFactory",
   "version": "1.4.1",
-  "released": false,
+  "released": true,
   "networkAddresses": {
     "1": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "5": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -2,7 +2,7 @@
   "defaultAddress": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",
   "contractName": "SignMessageLib",
   "version": "1.4.1",
-  "released": false,
+  "released": true,
   "networkAddresses": {
     "1": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",
     "100": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -1,6 +1,6 @@
 {
   "defaultAddress": "0x3d4BA2E0884aa488718476ca2FB8Efc291A46199",
-  "released": false,
+  "released": true,
   "contractName": "SimulateTxAccessor",
   "version": "1.4.1",
   "networkAddresses": {


### PR DESCRIPTION
This PR:
- Switches the released flag for 1.4.1 to true
- Adjusts tests that checked that the latest returned version was 1.3.0