### PR TITLE
Bump version to 1.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-deployments",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Collection of Safe singleton deployments",
   "homepage": "https://github.com/safe-global/safe-deployments/",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,10 +2814,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.1.2:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 pretty-format@^27.0.0, pretty-format@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
**This PR:**
- Bumps version to 1.33.0
- Updates lockfile because https://github.com/safe-global/safe-deployments/pull/386/ bumped a package version but didn't update the lockfile

# 1.33.0

## What's Changed
* Add 97 chain_id (bsc testnet) 1.4.1 safe contracts by @DmytroShalaiev in https://github.com/safe-global/safe-deployments/pull/372
* feat: add Optimism Sepolia Testnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/374
* feat: add Mode Sepolia Testnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/371
* feat: add Zora Testnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/369
* feat: add Berachain Artio Testnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/381
* feat: add unreal Testnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/385
* feat: add Taiko Katla L2 Testnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/383
* feat: Add Eclipse Testnet v1.3.0 contracts by @happyleow in https://github.com/safe-global/safe-deployments/pull/376
* feat: add Sei Devnet 1.3.0 contracts by @ElvisKrop in https://github.com/safe-global/safe-deployments/pull/390
* Add Additional Checks on Assets Folder by @nlordell in https://github.com/safe-global/safe-deployments/pull/386
* Add Kyoto Testnet v1.3.0 deployment by @kacperzuk-neti in https://github.com/safe-global/safe-deployments/pull/364
* Adding Shibarium deployment addresses by @melnour in https://github.com/safe-global/safe-deployments/pull/360
* Add Torus Testnet and Torus Mainnet v1.3.0 deployments by @donut-theory in https://github.com/safe-global/safe-deployments/pull/361
* feat: mantle sepolia deployments by @msvstj in https://github.com/safe-global/safe-deployments/pull/358

## New Contributors
* @DmytroShalaiev made their first contribution in https://github.com/safe-global/safe-deployments/pull/372
* @happyleow made their first contribution in https://github.com/safe-global/safe-deployments/pull/376
* @nlordell made their first contribution in https://github.com/safe-global/safe-deployments/pull/386
* @kacperzuk-neti made their first contribution in https://github.com/safe-global/safe-deployments/pull/364
* @melnour made their first contribution in https://github.com/safe-global/safe-deployments/pull/360

**Full Changelog**: https://github.com/safe-global/safe-deployments/compare/v1.32.0...v1.33.0