### PR TITLE
Add Networks Team As Codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @safe-global/safe-protocol
+* @safe-global/safe-protocol @gjeanmart


### PR DESCRIPTION
This would help the networks team facilitate releases when needed.