### PR TITLE
Add Code Hashes To All Deployments

### DIFF
--- a/src/__tests__/utilts.test.ts
+++ b/src/__tests__/utilts.test.ts
@@ -19,16 +19,18 @@ describe('utils.ts', () => {
         defaultAddress: '',
         version: '',
         abi: [],
-        networkAddresses: { "1": "0xbeef" },
+        networkAddresses: { "1": "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" },
         contractName: '',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         released: false,
       };
       const testReleasedDeployment: SingletonDeployment = {
         defaultAddress: '',
         version: '',
         abi: [],
-        networkAddresses: { "1": "0xbeef" },
+        networkAddresses: { "1": "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" },
         contractName: '',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         released: true, // Default filter value
       };
 
@@ -80,16 +82,18 @@ describe('utils.ts', () => {
         defaultAddress: '',
         version: '',
         abi: [],
-        networkAddresses: { "1": "0xbeef" },
+        networkAddresses: { "1": "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" },
         contractName: '',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         released: false,
       };
       const testReleasedDeployment: SingletonDeployment = {
         defaultAddress: '',
         version: '',
         abi: [],
-        networkAddresses: { "1": "0xbeef" },
+        networkAddresses: { "1": "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" },
         contractName: '',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         released: true, // Default filter value
       };
 
@@ -238,16 +242,18 @@ describe('utils.ts', () => {
         defaultAddress: '',
         version: '',
         abi: [],
-        networkAddresses: { "1": "0xbeef" },
+        networkAddresses: { "1": "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" },
         contractName: '',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         released: false,
       };
       const testReleasedDeployment: SingletonDeployment = {
         defaultAddress: '',
         version: '',
         abi: [],
-        networkAddresses: { "1": "0xbeef" },
+        networkAddresses: { "1": "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" },
         contractName: '',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         released: true, // Default filter value
       };
 

--- a/src/assets/v1.0.0/gnosis_safe.json
+++ b/src/assets/v1.0.0/gnosis_safe.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "GnosisSafe",
   "version": "1.0.0",
+  "codeHash": "0xe1f1593df76e69abc2d692792c80f329457551d5e83dde597546a1d58764da80",
   "networkAddresses": {
     "1": "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A",
     "4": "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A",
@@ -14,8 +15,14 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "owner", "type": "address" },
-        { "name": "_threshold", "type": "uint256" }
+        {
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "name": "_threshold",
+          "type": "uint256"
+        }
       ],
       "name": "addOwnerWithThreshold",
       "outputs": [],
@@ -27,16 +34,31 @@
       "constant": true,
       "inputs": [],
       "name": "DOMAIN_SEPARATOR_TYPEHASH",
-      "outputs": [{ "name": "", "type": "bytes32" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
       "constant": true,
-      "inputs": [{ "name": "owner", "type": "address" }],
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address"
+        }
+      ],
       "name": "isOwner",
-      "outputs": [{ "name": "", "type": "bool" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -44,29 +66,61 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "to", "type": "address" },
-        { "name": "value", "type": "uint256" },
-        { "name": "data", "type": "bytes" },
-        { "name": "operation", "type": "uint8" }
+        {
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "operation",
+          "type": "uint8"
+        }
       ],
       "name": "execTransactionFromModule",
-      "outputs": [{ "name": "success", "type": "bool" }],
+      "outputs": [
+        {
+          "name": "success",
+          "type": "bool"
+        }
+      ],
       "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "constant": true,
-      "inputs": [{ "name": "", "type": "bytes32" }],
+      "inputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "name": "signedMessages",
-      "outputs": [{ "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
       "constant": false,
-      "inputs": [{ "name": "module", "type": "address" }],
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address"
+        }
+      ],
       "name": "enableModule",
       "outputs": [],
       "payable": false,
@@ -75,7 +129,12 @@
     },
     {
       "constant": false,
-      "inputs": [{ "name": "_threshold", "type": "uint256" }],
+      "inputs": [
+        {
+          "name": "_threshold",
+          "type": "uint256"
+        }
+      ],
       "name": "changeThreshold",
       "outputs": [],
       "payable": false,
@@ -85,18 +144,34 @@
     {
       "constant": true,
       "inputs": [
-        { "name": "", "type": "address" },
-        { "name": "", "type": "bytes32" }
+        {
+          "name": "",
+          "type": "address"
+        },
+        {
+          "name": "",
+          "type": "bytes32"
+        }
       ],
       "name": "approvedHashes",
-      "outputs": [{ "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
       "constant": false,
-      "inputs": [{ "name": "_masterCopy", "type": "address" }],
+      "inputs": [
+        {
+          "name": "_masterCopy",
+          "type": "address"
+        }
+      ],
       "name": "changeMasterCopy",
       "outputs": [],
       "payable": false,
@@ -107,7 +182,12 @@
       "constant": true,
       "inputs": [],
       "name": "SENTINEL_MODULES",
-      "outputs": [{ "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -116,7 +196,12 @@
       "constant": true,
       "inputs": [],
       "name": "SENTINEL_OWNERS",
-      "outputs": [{ "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -125,7 +210,12 @@
       "constant": true,
       "inputs": [],
       "name": "getOwners",
-      "outputs": [{ "name": "", "type": "address[]" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -134,7 +224,12 @@
       "constant": true,
       "inputs": [],
       "name": "NAME",
-      "outputs": [{ "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -143,7 +238,12 @@
       "constant": true,
       "inputs": [],
       "name": "nonce",
-      "outputs": [{ "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -152,7 +252,12 @@
       "constant": true,
       "inputs": [],
       "name": "getModules",
-      "outputs": [{ "name": "", "type": "address[]" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -161,7 +266,12 @@
       "constant": true,
       "inputs": [],
       "name": "SAFE_MSG_TYPEHASH",
-      "outputs": [{ "name": "", "type": "bytes32" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -170,7 +280,12 @@
       "constant": true,
       "inputs": [],
       "name": "SAFE_TX_TYPEHASH",
-      "outputs": [{ "name": "", "type": "bytes32" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -178,8 +293,14 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "prevModule", "type": "address" },
-        { "name": "module", "type": "address" }
+        {
+          "name": "prevModule",
+          "type": "address"
+        },
+        {
+          "name": "module",
+          "type": "address"
+        }
       ],
       "name": "disableModule",
       "outputs": [],
@@ -190,9 +311,18 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "prevOwner", "type": "address" },
-        { "name": "oldOwner", "type": "address" },
-        { "name": "newOwner", "type": "address" }
+        {
+          "name": "prevOwner",
+          "type": "address"
+        },
+        {
+          "name": "oldOwner",
+          "type": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address"
+        }
       ],
       "name": "swapOwner",
       "outputs": [],
@@ -204,7 +334,12 @@
       "constant": true,
       "inputs": [],
       "name": "getThreshold",
-      "outputs": [{ "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -213,7 +348,12 @@
       "constant": true,
       "inputs": [],
       "name": "domainSeparator",
-      "outputs": [{ "name": "", "type": "bytes32" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -221,9 +361,18 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "prevOwner", "type": "address" },
-        { "name": "owner", "type": "address" },
-        { "name": "_threshold", "type": "uint256" }
+        {
+          "name": "prevOwner",
+          "type": "address"
+        },
+        {
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "name": "_threshold",
+          "type": "uint256"
+        }
       ],
       "name": "removeOwner",
       "outputs": [],
@@ -235,52 +384,101 @@
       "constant": true,
       "inputs": [],
       "name": "VERSION",
-      "outputs": [{ "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
-    { "payable": true, "stateMutability": "payable", "type": "fallback" },
+    {
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
     {
       "anonymous": false,
-      "inputs": [{ "indexed": false, "name": "txHash", "type": "bytes32" }],
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "txHash",
+          "type": "bytes32"
+        }
+      ],
       "name": "ExecutionFailed",
       "type": "event"
     },
     {
       "anonymous": false,
-      "inputs": [{ "indexed": false, "name": "owner", "type": "address" }],
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "owner",
+          "type": "address"
+        }
+      ],
       "name": "AddedOwner",
       "type": "event"
     },
     {
       "anonymous": false,
-      "inputs": [{ "indexed": false, "name": "owner", "type": "address" }],
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "owner",
+          "type": "address"
+        }
+      ],
       "name": "RemovedOwner",
       "type": "event"
     },
     {
       "anonymous": false,
-      "inputs": [{ "indexed": false, "name": "threshold", "type": "uint256" }],
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "threshold",
+          "type": "uint256"
+        }
+      ],
       "name": "ChangedThreshold",
       "type": "event"
     },
     {
       "anonymous": false,
-      "inputs": [{ "indexed": false, "name": "module", "type": "address" }],
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "module",
+          "type": "address"
+        }
+      ],
       "name": "EnabledModule",
       "type": "event"
     },
     {
       "anonymous": false,
-      "inputs": [{ "indexed": false, "name": "module", "type": "address" }],
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "module",
+          "type": "address"
+        }
+      ],
       "name": "DisabledModule",
       "type": "event"
     },
     {
       "anonymous": false,
       "inputs": [
-        { "indexed": false, "name": "newContract", "type": "address" }
+        {
+          "indexed": false,
+          "name": "newContract",
+          "type": "address"
+        }
       ],
       "name": "ContractCreation",
       "type": "event"
@@ -288,13 +486,34 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "_owners", "type": "address[]" },
-        { "name": "_threshold", "type": "uint256" },
-        { "name": "to", "type": "address" },
-        { "name": "data", "type": "bytes" },
-        { "name": "paymentToken", "type": "address" },
-        { "name": "payment", "type": "uint256" },
-        { "name": "paymentReceiver", "type": "address" }
+        {
+          "name": "_owners",
+          "type": "address[]"
+        },
+        {
+          "name": "_threshold",
+          "type": "uint256"
+        },
+        {
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "paymentToken",
+          "type": "address"
+        },
+        {
+          "name": "payment",
+          "type": "uint256"
+        },
+        {
+          "name": "paymentReceiver",
+          "type": "address"
+        }
       ],
       "name": "setup",
       "outputs": [],
@@ -305,19 +524,54 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "to", "type": "address" },
-        { "name": "value", "type": "uint256" },
-        { "name": "data", "type": "bytes" },
-        { "name": "operation", "type": "uint8" },
-        { "name": "safeTxGas", "type": "uint256" },
-        { "name": "baseGas", "type": "uint256" },
-        { "name": "gasPrice", "type": "uint256" },
-        { "name": "gasToken", "type": "address" },
-        { "name": "refundReceiver", "type": "address" },
-        { "name": "signatures", "type": "bytes" }
+        {
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "operation",
+          "type": "uint8"
+        },
+        {
+          "name": "safeTxGas",
+          "type": "uint256"
+        },
+        {
+          "name": "baseGas",
+          "type": "uint256"
+        },
+        {
+          "name": "gasPrice",
+          "type": "uint256"
+        },
+        {
+          "name": "gasToken",
+          "type": "address"
+        },
+        {
+          "name": "refundReceiver",
+          "type": "address"
+        },
+        {
+          "name": "signatures",
+          "type": "bytes"
+        }
       ],
       "name": "execTransaction",
-      "outputs": [{ "name": "success", "type": "bool" }],
+      "outputs": [
+        {
+          "name": "success",
+          "type": "bool"
+        }
+      ],
       "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
@@ -325,20 +579,42 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "to", "type": "address" },
-        { "name": "value", "type": "uint256" },
-        { "name": "data", "type": "bytes" },
-        { "name": "operation", "type": "uint8" }
+        {
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "operation",
+          "type": "uint8"
+        }
       ],
       "name": "requiredTxGas",
-      "outputs": [{ "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "constant": false,
-      "inputs": [{ "name": "hashToApprove", "type": "bytes32" }],
+      "inputs": [
+        {
+          "name": "hashToApprove",
+          "type": "bytes32"
+        }
+      ],
       "name": "approveHash",
       "outputs": [],
       "payable": false,
@@ -347,7 +623,12 @@
     },
     {
       "constant": false,
-      "inputs": [{ "name": "_data", "type": "bytes" }],
+      "inputs": [
+        {
+          "name": "_data",
+          "type": "bytes"
+        }
+      ],
       "name": "signMessage",
       "outputs": [],
       "payable": false,
@@ -357,20 +638,41 @@
     {
       "constant": false,
       "inputs": [
-        { "name": "_data", "type": "bytes" },
-        { "name": "_signature", "type": "bytes" }
+        {
+          "name": "_data",
+          "type": "bytes"
+        },
+        {
+          "name": "_signature",
+          "type": "bytes"
+        }
       ],
       "name": "isValidSignature",
-      "outputs": [{ "name": "", "type": "bytes4" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes4"
+        }
+      ],
       "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "constant": true,
-      "inputs": [{ "name": "message", "type": "bytes" }],
+      "inputs": [
+        {
+          "name": "message",
+          "type": "bytes"
+        }
+      ],
       "name": "getMessageHash",
-      "outputs": [{ "name": "", "type": "bytes32" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -378,19 +680,54 @@
     {
       "constant": true,
       "inputs": [
-        { "name": "to", "type": "address" },
-        { "name": "value", "type": "uint256" },
-        { "name": "data", "type": "bytes" },
-        { "name": "operation", "type": "uint8" },
-        { "name": "safeTxGas", "type": "uint256" },
-        { "name": "baseGas", "type": "uint256" },
-        { "name": "gasPrice", "type": "uint256" },
-        { "name": "gasToken", "type": "address" },
-        { "name": "refundReceiver", "type": "address" },
-        { "name": "_nonce", "type": "uint256" }
+        {
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "operation",
+          "type": "uint8"
+        },
+        {
+          "name": "safeTxGas",
+          "type": "uint256"
+        },
+        {
+          "name": "baseGas",
+          "type": "uint256"
+        },
+        {
+          "name": "gasPrice",
+          "type": "uint256"
+        },
+        {
+          "name": "gasToken",
+          "type": "address"
+        },
+        {
+          "name": "refundReceiver",
+          "type": "address"
+        },
+        {
+          "name": "_nonce",
+          "type": "uint256"
+        }
       ],
       "name": "encodeTransactionData",
-      "outputs": [{ "name": "", "type": "bytes" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
@@ -398,19 +735,54 @@
     {
       "constant": true,
       "inputs": [
-        { "name": "to", "type": "address" },
-        { "name": "value", "type": "uint256" },
-        { "name": "data", "type": "bytes" },
-        { "name": "operation", "type": "uint8" },
-        { "name": "safeTxGas", "type": "uint256" },
-        { "name": "baseGas", "type": "uint256" },
-        { "name": "gasPrice", "type": "uint256" },
-        { "name": "gasToken", "type": "address" },
-        { "name": "refundReceiver", "type": "address" },
-        { "name": "_nonce", "type": "uint256" }
+        {
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "operation",
+          "type": "uint8"
+        },
+        {
+          "name": "safeTxGas",
+          "type": "uint256"
+        },
+        {
+          "name": "baseGas",
+          "type": "uint256"
+        },
+        {
+          "name": "gasPrice",
+          "type": "uint256"
+        },
+        {
+          "name": "gasToken",
+          "type": "address"
+        },
+        {
+          "name": "refundReceiver",
+          "type": "address"
+        },
+        {
+          "name": "_nonce",
+          "type": "uint256"
+        }
       ],
       "name": "getTransactionHash",
-      "outputs": [{ "name": "", "type": "bytes32" }],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"

--- a/src/assets/v1.0.0/proxy_factory.json
+++ b/src/assets/v1.0.0/proxy_factory.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "ProxyFactory",
   "version": "1.0.0",
+  "codeHash": "0x84a375ad96ab395850d46cd601ed6354d3cf3fb67cec0caf18f34af5c9d1a7f0",
   "networkAddresses": {
     "1": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
     "4": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",

--- a/src/assets/v1.1.1/create_and_add_modules.json
+++ b/src/assets/v1.1.1/create_and_add_modules.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "CreateAndAddModules",
   "version": "1.1.1",
+  "codeHash": "0x83941bb48a3e3302a6e502e61513981ad02f3870f2d15e6d9cd301d616a0ba38",
   "networkAddresses": {
     "1": "0xF61A721642B0c0C8b334bA3763BA1326F53798C0",
     "4": "0xF61A721642B0c0C8b334bA3763BA1326F53798C0",
@@ -22,7 +23,11 @@
           "name": "proxyFactory",
           "type": "address"
         },
-        { "internalType": "bytes", "name": "data", "type": "bytes" }
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
       ],
       "name": "createAndAddModules",
       "outputs": [],

--- a/src/assets/v1.1.1/create_call.json
+++ b/src/assets/v1.1.1/create_call.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "CreateCall",
   "version": "1.1.1",
+  "codeHash": "0x9de5afc9afd2bc0e329d9b4fa34955da45bb8e11587c645c5ff5287d7507adeb",
   "networkAddresses": {
     "1": "0x8538FcBccba7f5303d2C679Fa5d7A629A8c9bf4A",
     "4": "0x8538FcBccba7f5303d2C679Fa5d7A629A8c9bf4A",

--- a/src/assets/v1.1.1/default_callback_handler.json
+++ b/src/assets/v1.1.1/default_callback_handler.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "DefaultCallbackHandler",
   "version": "1.1.1",
+  "codeHash": "0x919a9f5dd111a01f7a8e4b1f5c6a972bb2d1441c67bdec71de6a09d0be92f5b9",
   "networkAddresses": {
     "1": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
     "4": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",

--- a/src/assets/v1.1.1/gnosis_safe.json
+++ b/src/assets/v1.1.1/gnosis_safe.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "GnosisSafe",
   "version": "1.1.1",
+  "codeHash": "0x56b8be58b5ad629a621593a2e5e5e8e9a28408dc06e95597497b303902772e45",
   "networkAddresses": {
     "1": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
     "4": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",

--- a/src/assets/v1.1.1/multi_send.json
+++ b/src/assets/v1.1.1/multi_send.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "MultiSend",
   "version": "1.1.1",
+  "codeHash": "0xe4e9b4d4c1e3ff06cd51afe0b51eb1b22c0bab51eab38d428ee74540a5ff603e",
   "networkAddresses": {
     "1": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
     "4": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",

--- a/src/assets/v1.1.1/proxy_factory.json
+++ b/src/assets/v1.1.1/proxy_factory.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "ProxyFactory",
   "version": "1.1.1",
+  "codeHash": "0x0f0bb9c13be3b595d6f0fde841d5247a96f7e315bd8b97e1363553bee9a7d995",
   "networkAddresses": {
     "1": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
     "4": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",

--- a/src/assets/v1.2.0/gnosis_safe.json
+++ b/src/assets/v1.2.0/gnosis_safe.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "GnosisSafe",
   "version": "1.2.0",
+  "codeHash": "0x2ae2d1231f0d754a7fa4f5e5d0e5554085e1b500d8e09f95aaaaa3f49c0db922",
   "networkAddresses": {
     "1": "0x6851D6fDFAfD08c0295C392436245E5bc78B0185",
     "4": "0x6851D6fDFAfD08c0295C392436245E5bc78B0185",

--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "CompatibilityFallbackHandler",
   "version": "1.3.0",
+  "codeHash": "0x03e69f7ce809e81687c69b19a7d7cca45b6d551ffdec73d9bb87178476de1abf",
   "networkAddresses": {
     "1": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
     "3": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "CreateCall",
   "version": "1.3.0",
+  "codeHash": "0x8155d988823a4f6f1bcbc76a64af8e510c4ce68819290d43cf24956bd24dee82",
   "networkAddresses": {
     "1": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
     "3": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "GnosisSafe",
   "version": "1.3.0",
+  "codeHash": "0xbba688fbdb21ad2bb58bc320638b43d94e7d100f6f3ebaab0a4e4de6304b1c2e",
   "networkAddresses": {
     "1": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
     "3": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "GnosisSafeL2",
   "version": "1.3.0",
+  "codeHash": "0x21842597390c4c6e3c1239e434a682b054bd9548eee5e9b1d6a4482731023c0f",
   "networkAddresses": {
     "1": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
     "3": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "MultiSend",
   "version": "1.3.0",
+  "codeHash": "0x0208282bd262360d0320862c5ac70f375f5ed3b9d89a83a615b4d398415bdc83",
   "networkAddresses": {
     "1": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
     "3": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "MultiSendCallOnly",
   "version": "1.3.0",
+  "codeHash": "0xa9865ac2d9c7a1591619b188c4d88167b50df6cc0c5327fcbd1c8c75f7c066ad",
   "networkAddresses": {
     "1": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
     "3": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "GnosisSafeProxyFactory",
   "version": "1.3.0",
+  "codeHash": "0x337d7f54be11b6ed55fef7b667ea5488db53db8320a05d1146aa4bd169a39a9b",
   "networkAddresses": {
     "1": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
     "3": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -1,8 +1,9 @@
 {
   "defaultAddress": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+  "released": true,
   "contractName": "SignMessageLib",
   "version": "1.3.0",
-  "released": true,
+  "codeHash": "0x3ac65dea3cc9dd0d7b7b800f834e3d73415b4e944bb94555c3e4a08fb137e918",
   "networkAddresses": {
     "1": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
     "3": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "SimulateTxAccessor",
   "version": "1.3.0",
+  "codeHash": "0xb3fb9763869f2c09a2ac5a425d2dd6060bf7ef46b3899049d71a711e71e00f04",
   "networkAddresses": {
     "1": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
     "3": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",

--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "CompatibilityFallbackHandler",
   "version": "1.4.1",
+  "codeHash": "0x7c6007a5d711cea8dfd5d91f5940ec29c7f200fe511eb1fc1397b367af3c42f9",
   "networkAddresses": {
     "1": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
     "5": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "CreateCall",
   "version": "1.4.1",
+  "codeHash": "0x2b3060c55fcb8275653e99ad511a71f67ba76934ed66a7d74d6e68b52afff889",
   "networkAddresses": {
     "1": "0x9b35Af71d77eaf8d7e40252370304687390A1A52",
     "5": "0x9b35Af71d77eaf8d7e40252370304687390A1A52",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "MultiSend",
   "version": "1.4.1",
+  "codeHash": "0x0e4f7fc66550a322d1e7688e181b75e217e662a4f3f4d6a29b22bc61217c4b77",
   "networkAddresses": {
     "1": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
     "5": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "MultiSendCallOnly",
   "version": "1.4.1",
+  "codeHash": "0xecd5bd14a08c5d2122379900b2f272bdf107a7e92423c10dd5fe3254386c9939",
   "networkAddresses": {
     "1": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "5": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "Safe",
   "version": "1.4.1",
+  "codeHash": "0x1fe2df852ba3299d6534ef416eefa406e56ced995bca886ab7a553e6d0c5e1c4",
   "networkAddresses": {
     "1": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
     "5": "0x41675C099F32341bf84BFc5382aF534df5C7461a",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "SafeL2",
   "version": "1.4.1",
+  "codeHash": "0xb1f926978a0f44a2c0ec8fe822418ae969bd8c3f18d61e5103100339894f81ff",
   "networkAddresses": {
     "1": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "5": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -1,8 +1,9 @@
 {
   "defaultAddress": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
+  "released": true,
   "contractName": "SafeProxyFactory",
   "version": "1.4.1",
-  "released": true,
+  "codeHash": "0x50c3cdc4074750a7a974204a716c999edd37482f907608d960b2b025ee0b3317",
   "networkAddresses": {
     "1": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "5": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -1,8 +1,9 @@
 {
   "defaultAddress": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",
+  "released": true,
   "contractName": "SignMessageLib",
   "version": "1.4.1",
-  "released": true,
+  "codeHash": "0x525c754a46b79e05543a59bb61e8de3c9eee0d955a59352409cbe67ea1077528",
   "networkAddresses": {
     "1": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",
     "5": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -3,6 +3,7 @@
   "released": true,
   "contractName": "SimulateTxAccessor",
   "version": "1.4.1",
+  "codeHash": "0x91f82615581fc73b190b83d72e883608b25e392f72322035df1b13d51766cf8d",
   "networkAddresses": {
     "1": "0x3d4BA2E0884aa488718476ca2FB8Efc291A46199",
     "5": "0x3d4BA2E0884aa488718476ca2FB8Efc291A46199",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
 export interface SingletonDeployment {
     defaultAddress: string,
-    version: string,
-    abi: any[],
-    networkAddresses: Record<string, string>,
-    contractName: string,
     released: boolean
+    contractName: string,
+    version: string,
+    codeHash: string,
+    networkAddresses: Record<string, string>,
+    abi: any[],
 }
 
 export interface DeploymentFilter {


### PR DESCRIPTION
This PR adds code hashes to all deployment files. This is useful for a couple of reasons:

1. It makes it easier for external parties to verify the validity of the code at a specific address (even if it isn't at the expected `CREATE2` address)
2. It simplifies the `github-review.sh` script that @remedcu is working on in #649
3. Isn't "tech debt" like the `defaultAddress` field, as the code hash should be the same regardless of the deployment address (so it does not interfere with the plans to improve the deployment JSON format).

For posterity, the changes were generated with:

```fish
for f in src/assets/*/*.json
  set json "$(jq --arg h (jsonrpc $rpc eth_getCode (jq -r .defaultAddress $f) latest | hdwallet hex decode - | hdwallet hash data -) '{ defaultAddress, released, contractName, version, codeHash: $h, networkAddresses, abi }' $f)"
  echo "$json" > $f
end
```

Note that this makes a few formatting changes to some of the deployment files, but IMO this is a good thing (as we now have consistent formatting across all files :tada:).