### PR TITLE
Add A New GitHub Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: |
+          npm ci
+          bash bin/github-release.sh --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,4 @@
-build/
-node_modules/
 .DS_Store
-.zos.session
-.openzeppelin/.session
-deployments/
-env/
-.env
 dist/
-solc
-coverage/
-coverage.json
-yarn-error.log
-.idea
+node_modules/
+safe-global-safe-deployments-*.tgz

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -78,10 +78,14 @@ fi
 
 log "generating NPM packaging"
 npm pack
+package="${name#@}-${tag#v}.tgz"
+package="${package//\//-}"
 
 if [[ "$dryrun" == "n" ]]; then
 	log "creating draft release"
 	gh release delete "$tag" --yes &>/dev/null || true
 	gh release create "$tag" --draft --generate-notes --target "$(git rev-parse HEAD)" --title "$tag"
-	gh release upload "$tag" --clobber "safe-global-safe-deployments-${tag#v}.tgz"
+
+	log "uploading ${package}"
+	gh release upload "$tag" "${package}"
 fi

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+This script creates a draft GitHub release on the current commit.
+
+USAGE
+    bash bin/github-release.sh [-v|--verbose] [--no-push]
+
+OPTIONS
+    -v | --verbose      Verbose output
+    -n | --dry-run      Dry run; don't create any commits, tags, or draft a new
+                        release GitHub.
+
+EXAMPLES
+    bash bin/github-release.sh
+EOF
+}
+
+verbose=n
+dryrun=n
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-v|--verbose)
+		verbose=y
+		;;
+	-n|--dry-run)
+		dryrun=y
+		;;
+	*)
+		usage
+		exit 1
+		;;
+	esac
+	shift
+done
+
+log() {
+	if [[ "$verbose" == "y" ]]; then
+		echo "$@"
+	fi
+}
+
+if [[ -n "$(git status --porcelain)" ]]; then
+	echo "ERROR: Dirty Git index, please commit all changes before continuing" 1>&2
+	#exit 1
+fi
+if ! command -v gh &> /dev/null; then
+	echo "ERROR: Please install the 'gh' GitHub CLI" 1>&2
+	exit 1
+fi
+
+name=$(jq -r '.name' package.json)
+current=$(jq -r '.version' package.json)
+latest=$(npm view "$name" version)
+
+if [[ -n "$(git tag -l --points-at HEAD | awk '$1 == "v'$latest'"')" ]]; then
+	log "no changes since latest release"
+	exit 0
+elif [[ "$current" == "$latest" ]]; then
+	log "bumping version"
+	bump="patch"
+else
+	log "reusing current version"
+	bump="$current"
+fi
+tag=$(npm version "$bump" --allow-same-version --no-git-tag-version)
+
+if [[ "$dryrun" == "n" ]]; then
+	log "updating repository to $tag"
+	if [[ -n "$(git status --porcelain)" ]]; then
+		git commit -am "$tag"
+		git push origin
+	fi
+fi
+
+log "generating NPM packaging"
+npm pack
+
+if [[ "$dryrun" == "n" ]]; then
+	log "creating draft release"
+	gh release delete "$tag" --yes &>/dev/null || true
+	gh release create "$tag" --draft --generate-notes --target "$(git rev-parse HEAD)" --title "$tag"
+	gh release upload "$tag" --clobber "safe-global-safe-deployments-${tag#v}.tgz"
+fi

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -35,10 +35,10 @@ if ! command -v cast &> /dev/null; then
     exit 1
 fi
 
-if [[ "$#" -ne 4 ]]; then  
-    usage  
-    exit 1  
-fi 
+if [[ "$#" -ne 4 ]]; then
+    usage
+    exit 1
+fi
 if ! [[ $1 =~ ^[0-9]+$ ]]; then
     echo "ERROR: $1 is not a valid GitHub PR number" 1>&2
     usage


### PR DESCRIPTION
This PR adds a new GitHub workflow action to draft releases that can be used for publishing to NPM. Namely it will:

- Skip the workflow if the latest released NPM version matches the current release tag
- Bump the package version if needed and push to GitHub automatically (the configured username and email were taken from <https://github.com/actions/checkout/?tab=readme-ov-file#push-a-commit-using-the-built-in-token>)
- Draft a new release (note that this DOES NOT create a new tag, which is nice so we don't need to worry about force pushing/pulling tags).
- Create an NPM package tarball and attach it to the draft release.

The ultimate goal is that a separate runner will:
- Download the tarball
- Publish it to NPM

### Future Work

Somethings that are **NOT** included in this PR:
- Adding a scheduled run for the release process (this will come later when we are satisfied with the release process that we have)
- Publishing the GitHub release. Note that this can be trivially done with:
    ```sh
    gh release edit "$tag" --draft=false
    ```

In order to achieve these things, we plan on using the NPM registry as a source of truth - if there is an NPM package where the version matches the latest draft release, then we publish it. This is not included in the PR as it adds additional complexity and possible states that need to be handled by the script, and it was already complicated enough for now. Once we have our publishing runner up and working, then I will add support for this here.