### PR TITLE
Refactor GitHub Release Script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -83,11 +83,16 @@ if [[ -z "$draft" ]] && [[ "$current" == "$latest" ]]; then
 	fi
 
 	newtag="$(npm version patch --no-git-tag-version)"
+	branch="version/$newtag"
+	if git ls-remote --heads origin | grep "refs/heads/$branch\$"; then
+		log "version bump PR already exists"
+		exit 0
+	fi
 	if [[ "$dryrun" == "n" ]]; then
 		log "updating repository to $newtag"
-		git checkout -b "version/$newtag"
+		git checkout -b "$branch"
 		git commit -am "$newtag"
-		git push -u origin "version/$newtag"
+		git push -u origin "$branch"
 		gh pr create --fill
 	fi
 elif [[ "$current" != "$latest" ]]; then

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -4,10 +4,15 @@ set -euo pipefail
 
 usage() {
     cat <<EOF
-This script creates a draft GitHub release on the current commit.
+Script for managing the GitHub release process.
+
+It provides functionality for automatically:
+ • Creating GitHub pull requests for bumping version numbers
+ • Drafting new GitHub releases
+ • Publishing GitHub releases once the version lands on NPM
 
 USAGE
-    bash bin/github-release.sh [-v|--verbose] [--no-push]
+    bash bin/github-release.sh [-v|--verbose] [-n|--dry-run]
 
 OPTIONS
     -v | --verbose      Verbose output
@@ -19,15 +24,15 @@ EXAMPLES
 EOF
 }
 
-verbose=n
-dryrun=n
+verbose="n"
+dryrun="n"
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-v|--verbose)
-		verbose=y
+		verbose="y"
 		;;
 	-n|--dry-run)
-		dryrun=y
+		dryrun="y"
 		;;
 	*)
 		usage
@@ -45,47 +50,79 @@ log() {
 
 if [[ -n "$(git status --porcelain)" ]]; then
 	echo "ERROR: Dirty Git index, please commit all changes before continuing" 1>&2
-	#exit 1
+	if [[ "$dryrun" == "n" ]]; then
+		exit 1
+	fi
 fi
 if ! command -v gh &> /dev/null; then
 	echo "ERROR: Please install the 'gh' GitHub CLI" 1>&2
 	exit 1
 fi
 
-name=$(jq -r '.name' package.json)
-current=$(jq -r '.version' package.json)
-latest=$(npm view "$name" version)
+name="$(jq -r '.name' package.json)"
+current="$(jq -r '.version' package.json)"
+latest="$(npm view "$name" version)"
 
-if [[ -n "$(git tag -l --points-at HEAD | awk '$1 == "v'$latest'"')" ]]; then
-	log "no changes since latest release"
-	exit 0
-elif [[ "$current" == "$latest" ]]; then
-	log "bumping version"
-	bump="patch"
-else
-	log "reusing current version"
-	bump="$current"
+if ! printf "%s\n" "$latest" "$current" | sort -C -V; then
+	echo "ERROR: Latest NPM version is newer than current version" 1>&2
+	exit 1
 fi
-tag=$(npm version "$bump" --allow-same-version --no-git-tag-version)
 
-if [[ "$dryrun" == "n" ]]; then
-	log "updating repository to $tag"
-	if [[ -n "$(git status --porcelain)" ]]; then
-		git commit -am "$tag"
-		git push origin
+tag="v$current"
+draft="$(gh release view "$tag" --json targetCommitish --jq .targetCommitish 2>/dev/null || true)"
+
+if [[ -z "$draft" ]] && [[ "$current" == "$latest" ]]; then
+	# In this case, we have no existing draft, and the current version is
+	# the same as the latest release, so we need to create a new PR to bump
+	# the package version.
+	log "==> Bumping Version"
+
+	if [[ -n "$(git tag -l --points-at HEAD | awk '$1 == "'$tag'"')" ]]; then
+		echo "INFO: No changes since latest release"
+		exit 0
 	fi
-fi
 
-log "generating NPM packaging"
-npm pack
-package="${name#@}-${tag#v}.tgz"
-package="${package//\//-}"
+	newtag="$(npm version patch --no-git-tag-version)"
+	if [[ "$dryrun" == "n" ]]; then
+		log "updating repository to $newtag"
+		git checkout -b "version/$newtag"
+		git commit -am "$newtag"
+		git push -u origin "version/$newtag"
+		gh pr create --fill
+	fi
+elif [[ "$current" != "$latest" ]]; then
+	# In this case, the current version is newer that the latest released
+	# version on NPM, so we create or update the draft release to ensure it
+	# includes the latest version.
+	log "==> Drafting Release"
 
-if [[ "$dryrun" == "n" ]]; then
-	log "creating draft release"
-	gh release delete "$tag" --yes &>/dev/null || true
-	gh release create "$tag" --draft --generate-notes --target "$(git rev-parse HEAD)" --title "$tag"
+	commit="$(git rev-parse HEAD)"
+	if [[ "$commit" == "$draft" ]]; then
+		log "draft is already at latest commit"
+		exit 0
+	fi
 
-	log "uploading ${package}"
-	gh release upload "$tag" "${package}"
+	log "generating NPM packaging"
+	npm pack
+	package="${name#@}-$current.tgz"
+	package="${package//\//-}"
+
+	if [[ "$dryrun" == "n" ]]; then
+		log "drafting release with NPM tarball"
+		if [[ -n "$draft" ]]; then
+			log "cleaning up existing draft"
+			gh release delete "$tag" --yes
+		fi
+		gh release create "$tag" --draft --generate-notes --target "$commit" --title "$tag" "$package"
+	fi
+else # if [[ -n "$draft" ]] && [[ "$current" == "$latest" ]]; then
+	# In this case, there is an existing draft, and the latest version is
+	# equal to it. Publish the draft release!
+	log "==> Publishing Release"
+
+	tag="v$current"
+	if [[ "$dryrun" == "n" ]]; then
+		log "publishing draft release"
+		gh release edit "$tag" --draft=false
+	fi
 fi


### PR DESCRIPTION
This PR completely refactors the release script :see_no_evil:.

The previous script was built on the assumption that GitHub actions could push to protected branches, but it turns out that this is kind of complicated to setup without sacrificing some branch protections that we apply to `main` and I don't want to touch.

Instead, we change the release flow to:
1. Automatically create a PR to GitHub to bump the version
2. Create a draft release
3. Publish the draft release once it shows up on NPM.

### Test Plan

This script should do all that now, and once this merges, we should be able to test the flow by:
1. Triggering the flow to create the version bump PR
2. Merge the version bump PR
3. Triggering the flow to create a draft release
4. NPM publish the tarball attached to the release
5. Triggering the flow to publish the draft release

Tested on my local fork and was able to automatically create releases.

<details><summary>Screenshots</summary>

![image](https://github.com/safe-global/safe-deployments/assets/4210206/747fcf6f-4e9a-4c5a-8f8d-bc6955c345a7)

![image](https://github.com/safe-global/safe-deployments/assets/4210206/52e5e6c6-a428-4bd6-9d30-4264c29ce6d3)

![image](https://github.com/safe-global/safe-deployments/assets/4210206/bda8cd1c-74a2-43ae-bf22-5e0069d06d5d)

</details>

### Future Work

Once the private runner that publishes to NPM is setup, we can run the action hourly.