### PR TITLE
Do Not Add Reviewer To Version Bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -22,3 +20,5 @@ jobs:
       - run: |
           npm ci
           bash bin/github-release.sh --verbose
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -103,7 +103,7 @@ if [[ -z "$draft" ]] && [[ "$current" == "$latest" ]]; then
 		git checkout -b "$branch"
 		git commit -am "Bump Version to $newtag"
 		git push -u origin "$branch"
-		gh pr create --fill --reviewer safe-global/safe-protocol
+		gh pr create --fill
 	fi
 elif [[ "$current" != "$latest" ]]; then
 	# In this case, the current version is newer that the latest released


### PR DESCRIPTION
This PR removes the `--reviewer` when creating the version bump PR. The reason is that this was causing CI to [fail](https://github.com/safe-global/safe-deployments/actions/runs/9782471522/job/27008850846#step:5:37) with:

> ```
> could not request reviewer: 'safe-global/safe-protocol' not found
> ```

From what I understand, this is because the automatically created GitHub token that gets injected in the GitHub actions (`github.token`) is scoped to the repository and does not have org access in order to "find" the team and adding to ([source](https://github.com/cli/cli/issues/6395)).

I did not catch this in my local debugging as I did not have a team to test with to add to the reviewers, so did not run into this problem.

I also took this opportunity to scope the `GH_TOKEN` environment variable to _only_ the step that runs the release script, instead of all the steps.