### PR TITLE
Feature: Multiple deployments functions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,13 @@
-import eslint from "@eslint/js";
-import tseslint from "typescript-eslint";
-import prettier from "eslint-plugin-prettier/recommended";
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-plugin-prettier/recommended';
 
 export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     rules: {
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        { ignoreRestSiblings: true },
-      ],
+      '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
     },
   },
   prettier,

--- a/src/__tests__/assets.test.ts
+++ b/src/__tests__/assets.test.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import { SingletonDeploymentJSON } from '../types';
+import { SingletonDeploymentJSON, AddressType } from '../types';
 
-const KNOWN_ADDRESS_TYPES = ['canonical', 'eip155', 'zksync'];
+const KNOWN_ADDRESS_TYPES: AddressType[] = ['canonical', 'eip155', 'zksync'];
 
 function assetPath(...paths: string[]) {
   return path.join(__dirname, '..', 'assets', ...paths);
@@ -45,7 +45,7 @@ describe('assets/', () => {
               expect(keys).toEqual(sorted);
             });
 
-            it('networks should only contain canonical address types', async () => {
+            it('networks should only contain known address types', async () => {
               const deploymentJson = await readAssetJSON(version, file);
               if (!deploymentJson) {
                 throw new Error(`Failed to read asset ${version}/${file}`);

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -8,264 +8,323 @@ import GnosisSafe111 from './assets/v1/v1.1.1/gnosis_safe.json';
 import GnosisSafe100 from './assets/v1/v1.0.0/gnosis_safe.json';
 import { findDeployment } from '../utils';
 import { _safeDeployments, _safeL2Deployments } from '../safes';
-import { SingletonDeployment, SingletonDeploymentJSON } from '../types';
+import { SingletonDeployment, SingletonDeploymentJSON, DeploymentFormats, SingletonDeploymentV2 } from '../types';
 
 const _safeDeploymentsReverse = [..._safeDeployments].reverse();
 
 describe('utils.ts', () => {
   describe('findDeployment', () => {
-    it('should filter by released by default', () => {
-      const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
-        version: '',
-        abi: [],
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': 'canonical' },
-        contractName: '',
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: false,
-      };
-      const testReleasedDeploymentJson: SingletonDeploymentJSON = {
-        version: '',
-        abi: [],
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': 'canonical' },
-        contractName: '',
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: true, // Default filter value
-      };
-      const testReleasedDeployment: SingletonDeployment = {
-        defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: true,
-        abi: [],
-        version: '',
-        contractName: '',
-      };
+    describe('singleton format', () => {
+      it('should filter by released by default', () => {
+        const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': 'canonical' },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: false,
+        };
+        const testReleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': 'canonical' },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: true, // Default filter value
+        };
+        const testReleasedDeployment: SingletonDeployment = {
+          defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: true,
+          abi: [],
+          version: '',
+          contractName: '',
+        };
 
-      const testDeployments = [testUnreleasedDeploymentJson, testUnreleasedDeploymentJson, testReleasedDeploymentJson];
+        const testDeployments = [
+          testUnreleasedDeploymentJson,
+          testUnreleasedDeploymentJson,
+          testReleasedDeploymentJson,
+        ];
 
-      expect(findDeployment(undefined, testDeployments)).toMatchObject(testReleasedDeployment);
+        expect(findDeployment(undefined, testDeployments)).toMatchObject(testReleasedDeployment);
 
-      // should preserve the released flag even if its not explicitly passed
-      expect(findDeployment({ network: '1' }, testDeployments)).toMatchObject(testReleasedDeployment);
+        // should preserve the released flag even if its not explicitly passed
+        expect(findDeployment({ network: '1' }, testDeployments)).toMatchObject(testReleasedDeployment);
+      });
+
+      it('should return the correct deployment (filtered by version)', () => {
+        // Chronological deployments
+        expect(findDeployment({ version: '1.3.0' }, _safeDeployments)).toMatchObject(GnosisSafe130);
+        expect(findDeployment({ version: '1.2.0' }, _safeDeployments)).toMatchObject(GnosisSafe120);
+        expect(findDeployment({ version: '1.1.1' }, _safeDeployments)).toMatchObject(GnosisSafe111);
+        expect(findDeployment({ version: '1.0.0' }, _safeDeployments)).toMatchObject(GnosisSafe100);
+        // Incorrect filter:
+        expect(findDeployment({ version: '2.0.0' }, _safeDeployments)).toBeUndefined();
+
+        // L2 deployments
+        expect(findDeployment({ version: '1.3.0+L2' }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
+        // Incorrect filter:
+        expect(findDeployment({ version: '2.0.0+L2' }, _safeL2Deployments)).toBeUndefined();
+      });
+
+      it('should return the correct deployment (filtered by released flag)', () => {
+        const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': 'canonical' },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: false,
+        };
+        const testReleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': 'canonical' },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: true, // Default filter value
+        };
+        const testUnreleasedDeployment: SingletonDeployment = {
+          defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: false,
+          abi: [],
+          version: '',
+          contractName: '',
+        };
+
+        const testDeployments = [testUnreleasedDeploymentJson, testReleasedDeploymentJson];
+
+        // Chronological deployments
+        expect(findDeployment({ released: true }, _safeDeployments)).toMatchObject(Safe141);
+
+        // Reverse chronological deployments
+        expect(findDeployment({ released: true }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
+        // Released flag set to false:
+        expect(findDeployment({ released: false }, testDeployments)).toMatchObject(testUnreleasedDeployment);
+
+        // L2 deployments
+        expect(findDeployment({ released: true }, _safeL2Deployments)).toMatchObject(SafeL2141);
+      });
+
+      it('should return the correct deployment (filtered by network)', () => {
+        // Reverse chronological deployments
+        expect(findDeployment({ network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
+        expect(findDeployment({ network: '73799' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe111);
+        expect(findDeployment({ network: '11297108109' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe130);
+        // Incorrect filter:
+        expect(findDeployment({ network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
+
+        // L2 deployments
+        expect(findDeployment({ network: '100' }, _safeL2Deployments)).toMatchObject(SafeL2141);
+        // Incorrect filter:
+        expect(findDeployment({ network: '0' }, _safeL2Deployments)).toBeUndefined();
+      });
+      it('should return the correct deployment (filtered by version and released)', () => {
+        // Chronological deployments
+        expect(findDeployment({ version: '1.3.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe130);
+        expect(findDeployment({ version: '1.2.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe120);
+        expect(findDeployment({ version: '1.1.1', released: true }, _safeDeployments)).toMatchObject(GnosisSafe111);
+        expect(findDeployment({ version: '1.0.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe100);
+        // Incorrect filter:
+        expect(findDeployment({ version: '1.0.0', released: false }, _safeDeployments)).toBeUndefined();
+
+        // L2 deployments
+        expect(findDeployment({ version: '1.3.0', released: true }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
+        expect(findDeployment({ version: '1.3.0+L2', released: true }, _safeL2Deployments)).toMatchObject(
+          GnosisSafeL2130,
+        );
+        // Incorrect filter:
+        expect(findDeployment({ version: '1.3.0+L2', released: false }, _safeL2Deployments)).toBeUndefined();
+      });
+      it('should return the correct deployment (filtered by version and network)', () => {
+        // Reverse chronological deployments
+        expect(findDeployment({ version: '1.0.0', network: '1' }, _safeDeploymentsReverse)).toMatchObject(
+          GnosisSafe100,
+        );
+        expect(findDeployment({ version: '1.1.1', network: '1' }, _safeDeploymentsReverse)).toMatchObject(
+          GnosisSafe111,
+        );
+        expect(findDeployment({ version: '1.2.0', network: '1' }, _safeDeploymentsReverse)).toMatchObject(
+          GnosisSafe120,
+        );
+        expect(findDeployment({ version: '1.3.0', network: '1' }, _safeDeploymentsReverse)).toMatchObject(
+          GnosisSafe130,
+        );
+        // Incorrect filter:
+        expect(findDeployment({ version: '1.3.0', network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
+
+        // L2 deployments
+        expect(findDeployment({ version: '1.3.0', network: '100' }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
+        expect(findDeployment({ version: '1.3.0+L2', network: '100' }, _safeL2Deployments)).toMatchObject(
+          GnosisSafeL2130,
+        );
+        // Incorrect filter:
+        expect(findDeployment({ version: '1.3.0+L2', network: '0' }, _safeL2Deployments)).toBeUndefined();
+      });
+      it('should return the correct deployment (filtered by released and network)', () => {
+        const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': 'canonical' },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: false,
+        };
+        const testReleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': 'canonical' },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: true, // Default filter value
+        };
+        const testUnreleasedDeployment: SingletonDeployment = {
+          defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: false,
+          abi: [],
+          version: '',
+          contractName: '',
+        };
+
+        const testDeployments = [
+          testUnreleasedDeploymentJson,
+          testUnreleasedDeploymentJson,
+          testReleasedDeploymentJson,
+        ];
+
+        // Reverse chronological deployments
+        expect(findDeployment({ released: true, network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
+        expect(findDeployment({ released: true, network: '246' }, _safeDeploymentsReverse)).toMatchObject(
+          GnosisSafe111,
+        );
+        expect(findDeployment({ released: true, network: '11297108109' }, _safeDeploymentsReverse)).toMatchObject(
+          GnosisSafe130,
+        );
+        // Incorrect filter:
+        expect(findDeployment({ released: true, network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
+        expect(findDeployment({ released: false, network: '1' }, testDeployments)).toMatchObject(
+          testUnreleasedDeployment,
+        );
+
+        // L2 deployments
+        expect(findDeployment({ released: true, network: '100' }, _safeL2Deployments)).toMatchObject(SafeL2141);
+        // Incorrect filter:
+        expect(findDeployment({ released: true, network: '0' }, _safeL2Deployments)).toBeUndefined();
+        expect(findDeployment({ released: false, network: '100' }, testDeployments)).toBeUndefined();
+      });
+      it('should return the correct deployment (filtered by version, released and network)', () => {
+        // Reverse chronological deployments
+        expect(
+          findDeployment({ version: '1.0.0', released: true, network: '1' }, _safeDeploymentsReverse),
+        ).toMatchObject(GnosisSafe100);
+        expect(
+          findDeployment({ version: '1.1.1', released: true, network: '246' }, _safeDeploymentsReverse),
+        ).toMatchObject(GnosisSafe111);
+        expect(
+          findDeployment({ version: '1.2.0', released: true, network: '73799' }, _safeDeploymentsReverse),
+        ).toMatchObject(GnosisSafe120);
+        expect(
+          findDeployment({ version: '1.3.0', released: true, network: '11297108109' }, _safeDeploymentsReverse),
+        ).toMatchObject(GnosisSafe130);
+        // Incorrect filter:
+        expect(
+          findDeployment({ version: '1.3.0', released: false, network: '11297108109' }, _safeDeploymentsReverse),
+        ).toBeUndefined();
+        expect(
+          findDeployment({ version: '1.3.0', released: true, network: '0' }, _safeDeploymentsReverse),
+        ).toBeUndefined();
+        expect(
+          findDeployment({ version: '2.0.0', released: true, network: '11297108109' }, _safeDeploymentsReverse),
+        ).toBeUndefined();
+
+        // L2 deployments
+        expect(findDeployment({ version: '1.3.0', released: true, network: '100' }, _safeL2Deployments)).toMatchObject(
+          GnosisSafeL2130,
+        );
+        expect(
+          findDeployment({ version: '1.3.0+L2', released: true, network: '100' }, _safeL2Deployments),
+        ).toMatchObject(GnosisSafeL2130);
+        // Incorrect filter:
+        expect(
+          findDeployment({ version: '1.3.0+L2', released: false, network: '100' }, _safeL2Deployments),
+        ).toBeUndefined();
+        expect(
+          findDeployment({ version: '1.3.0+L2', released: true, network: '0' }, _safeL2Deployments),
+        ).toBeUndefined();
+        expect(
+          findDeployment({ version: '2.0.0+L2', released: true, network: '100' }, _safeL2Deployments),
+        ).toBeUndefined();
+      });
     });
 
-    it('should return the correct deployment (filtered by version)', () => {
-      // Chronological deployments
-      expect(findDeployment({ version: '1.3.0' }, _safeDeployments)).toMatchObject(GnosisSafe130);
-      expect(findDeployment({ version: '1.2.0' }, _safeDeployments)).toMatchObject(GnosisSafe120);
-      expect(findDeployment({ version: '1.1.1' }, _safeDeployments)).toMatchObject(GnosisSafe111);
-      expect(findDeployment({ version: '1.0.0' }, _safeDeployments)).toMatchObject(GnosisSafe100);
-      // Incorrect filter:
-      expect(findDeployment({ version: '2.0.0' }, _safeDeployments)).toBeUndefined();
+    describe('multiple format', () => {
+      it('should populate the networkAddresses field', () => {
+        const testReleasedDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+            eip155: '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe',
+            zksync: '0xbabebabebabebabebabebabebabebabebabebabe',
+          },
+          networkAddresses: { '1': 'canonical', '100': 'zksync', '101': ['canonical', 'eip155'] },
+          contractName: '',
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: true, // Default filter value
+        };
+        const expectedDeployment: SingletonDeploymentV2 = {
+          addresses: {
+            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          },
+          networkAddresses: {
+            '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+            '100': '0xbabebabebabebabebabebabebabebabebabebabe',
+            '101': ['0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef', '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe'],
+          },
+          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          released: true,
+          abi: [],
+          version: '',
+          contractName: '',
+        };
 
-      // L2 deployments
-      expect(findDeployment({ version: '1.3.0+L2' }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
-      // Incorrect filter:
-      expect(findDeployment({ version: '2.0.0+L2' }, _safeL2Deployments)).toBeUndefined();
-    });
+        const testDeployments = [testReleasedDeploymentJson];
 
-    it('should return the correct deployment (filtered by released flag)', () => {
-      const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
-        version: '',
-        abi: [],
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': 'canonical' },
-        contractName: '',
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: false,
-      };
-      const testReleasedDeploymentJson: SingletonDeploymentJSON = {
-        version: '',
-        abi: [],
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': 'canonical' },
-        contractName: '',
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: true, // Default filter value
-      };
-      const testUnreleasedDeployment: SingletonDeployment = {
-        defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: false,
-        abi: [],
-        version: '',
-        contractName: '',
-      };
-
-      const testDeployments = [testUnreleasedDeploymentJson, testReleasedDeploymentJson];
-
-      // Chronological deployments
-      expect(findDeployment({ released: true }, _safeDeployments)).toMatchObject(Safe141);
-
-      // Reverse chronological deployments
-      expect(findDeployment({ released: true }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
-      // Released flag set to false:
-      expect(findDeployment({ released: false }, testDeployments)).toMatchObject(testUnreleasedDeployment);
-
-      // L2 deployments
-      expect(findDeployment({ released: true }, _safeL2Deployments)).toMatchObject(SafeL2141);
-    });
-
-    it('should return the correct deployment (filtered by network)', () => {
-      // Reverse chronological deployments
-      expect(findDeployment({ network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
-      expect(findDeployment({ network: '73799' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe111);
-      expect(findDeployment({ network: '11297108109' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe130);
-      // Incorrect filter:
-      expect(findDeployment({ network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
-
-      // L2 deployments
-      expect(findDeployment({ network: '100' }, _safeL2Deployments)).toMatchObject(SafeL2141);
-      // Incorrect filter:
-      expect(findDeployment({ network: '0' }, _safeL2Deployments)).toBeUndefined();
-    });
-    it('should return the correct deployment (filtered by version and released)', () => {
-      // Chronological deployments
-      expect(findDeployment({ version: '1.3.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe130);
-      expect(findDeployment({ version: '1.2.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe120);
-      expect(findDeployment({ version: '1.1.1', released: true }, _safeDeployments)).toMatchObject(GnosisSafe111);
-      expect(findDeployment({ version: '1.0.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe100);
-      // Incorrect filter:
-      expect(findDeployment({ version: '1.0.0', released: false }, _safeDeployments)).toBeUndefined();
-
-      // L2 deployments
-      expect(findDeployment({ version: '1.3.0', released: true }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
-      expect(findDeployment({ version: '1.3.0+L2', released: true }, _safeL2Deployments)).toMatchObject(
-        GnosisSafeL2130,
-      );
-      // Incorrect filter:
-      expect(findDeployment({ version: '1.3.0+L2', released: false }, _safeL2Deployments)).toBeUndefined();
-    });
-    it('should return the correct deployment (filtered by version and network)', () => {
-      // Reverse chronological deployments
-      expect(findDeployment({ version: '1.0.0', network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
-      expect(findDeployment({ version: '1.1.1', network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe111);
-      expect(findDeployment({ version: '1.2.0', network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe120);
-      expect(findDeployment({ version: '1.3.0', network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe130);
-      // Incorrect filter:
-      expect(findDeployment({ version: '1.3.0', network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
-
-      // L2 deployments
-      expect(findDeployment({ version: '1.3.0', network: '100' }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
-      expect(findDeployment({ version: '1.3.0+L2', network: '100' }, _safeL2Deployments)).toMatchObject(
-        GnosisSafeL2130,
-      );
-      // Incorrect filter:
-      expect(findDeployment({ version: '1.3.0+L2', network: '0' }, _safeL2Deployments)).toBeUndefined();
-    });
-    it('should return the correct deployment (filtered by released and network)', () => {
-      const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
-        version: '',
-        abi: [],
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': 'canonical' },
-        contractName: '',
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: false,
-      };
-      const testReleasedDeploymentJson: SingletonDeploymentJSON = {
-        version: '',
-        abi: [],
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': 'canonical' },
-        contractName: '',
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: true, // Default filter value
-      };
-      const testUnreleasedDeployment: SingletonDeployment = {
-        defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        addresses: {
-          canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-        },
-        networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
-        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        released: false,
-        abi: [],
-        version: '',
-        contractName: '',
-      };
-
-      const testDeployments = [testUnreleasedDeploymentJson, testUnreleasedDeploymentJson, testReleasedDeploymentJson];
-
-      // Reverse chronological deployments
-      expect(findDeployment({ released: true, network: '1' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
-      expect(findDeployment({ released: true, network: '246' }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe111);
-      expect(findDeployment({ released: true, network: '11297108109' }, _safeDeploymentsReverse)).toMatchObject(
-        GnosisSafe130,
-      );
-      // Incorrect filter:
-      expect(findDeployment({ released: true, network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
-      expect(findDeployment({ released: false, network: '1' }, testDeployments)).toMatchObject(
-        testUnreleasedDeployment,
-      );
-
-      // L2 deployments
-      expect(findDeployment({ released: true, network: '100' }, _safeL2Deployments)).toMatchObject(SafeL2141);
-      // Incorrect filter:
-      expect(findDeployment({ released: true, network: '0' }, _safeL2Deployments)).toBeUndefined();
-      expect(findDeployment({ released: false, network: '100' }, testDeployments)).toBeUndefined();
-    });
-    it('should return the correct deployment (filtered by version, released and network)', () => {
-      // Reverse chronological deployments
-      expect(findDeployment({ version: '1.0.0', released: true, network: '1' }, _safeDeploymentsReverse)).toMatchObject(
-        GnosisSafe100,
-      );
-      expect(
-        findDeployment({ version: '1.1.1', released: true, network: '246' }, _safeDeploymentsReverse),
-      ).toMatchObject(GnosisSafe111);
-      expect(
-        findDeployment({ version: '1.2.0', released: true, network: '73799' }, _safeDeploymentsReverse),
-      ).toMatchObject(GnosisSafe120);
-      expect(
-        findDeployment({ version: '1.3.0', released: true, network: '11297108109' }, _safeDeploymentsReverse),
-      ).toMatchObject(GnosisSafe130);
-      // Incorrect filter:
-      expect(
-        findDeployment({ version: '1.3.0', released: false, network: '11297108109' }, _safeDeploymentsReverse),
-      ).toBeUndefined();
-      expect(
-        findDeployment({ version: '1.3.0', released: true, network: '0' }, _safeDeploymentsReverse),
-      ).toBeUndefined();
-      expect(
-        findDeployment({ version: '2.0.0', released: true, network: '11297108109' }, _safeDeploymentsReverse),
-      ).toBeUndefined();
-
-      // L2 deployments
-      expect(findDeployment({ version: '1.3.0', released: true, network: '100' }, _safeL2Deployments)).toMatchObject(
-        GnosisSafeL2130,
-      );
-      expect(findDeployment({ version: '1.3.0+L2', released: true, network: '100' }, _safeL2Deployments)).toMatchObject(
-        GnosisSafeL2130,
-      );
-      // Incorrect filter:
-      expect(
-        findDeployment({ version: '1.3.0+L2', released: false, network: '100' }, _safeL2Deployments),
-      ).toBeUndefined();
-      expect(findDeployment({ version: '1.3.0+L2', released: true, network: '0' }, _safeL2Deployments)).toBeUndefined();
-      expect(
-        findDeployment({ version: '2.0.0+L2', released: true, network: '100' }, _safeL2Deployments),
-      ).toBeUndefined();
+        expect(findDeployment({}, testDeployments, DeploymentFormats.MULTIPLE)).toMatchObject(expectedDeployment);
+      });
     });
   });
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -7,10 +7,10 @@ import GnosisSafe120 from './assets/v1/v1.2.0/gnosis_safe.json';
 import GnosisSafe111 from './assets/v1/v1.1.1/gnosis_safe.json';
 import GnosisSafe100 from './assets/v1/v1.0.0/gnosis_safe.json';
 import { findDeployment } from '../utils';
-import { _safeDeployments, _safeL2Deployments } from '../safes';
+import { _SAFE_DEPLOYMENTS, _SAFE_L2_DEPLOYMENTS } from '../deployments';
 import { SingletonDeployment, SingletonDeploymentJSON, DeploymentFormats, SingletonDeploymentV2 } from '../types';
 
-const _safeDeploymentsReverse = [..._safeDeployments].reverse();
+const _safeDeploymentsReverse = [..._SAFE_DEPLOYMENTS].reverse();
 
 describe('utils.ts', () => {
   describe('findDeployment', () => {
@@ -19,32 +19,38 @@ describe('utils.ts', () => {
         const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
           version: '',
           abi: [],
-          addresses: {
-            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          deployments: {
+            canonical: {
+              address: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
           },
           networkAddresses: { '1': 'canonical' },
           contractName: '',
-          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           released: false,
         };
         const testReleasedDeploymentJson: SingletonDeploymentJSON = {
           version: '',
           abi: [],
-          addresses: {
-            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          deployments: {
+            canonical: {
+              address: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
           },
           networkAddresses: { '1': 'canonical' },
           contractName: '',
-          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           released: true, // Default filter value
         };
         const testReleasedDeployment: SingletonDeployment = {
           defaultAddress: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-          addresses: {
-            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          deployments: {
+            canonical: {
+              address: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
           },
           networkAddresses: { '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef' },
-          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           released: true,
           abi: [],
           version: '',
@@ -65,17 +71,17 @@ describe('utils.ts', () => {
 
       it('should return the correct deployment (filtered by version)', () => {
         // Chronological deployments
-        expect(findDeployment({ version: '1.3.0' }, _safeDeployments)).toMatchObject(GnosisSafe130);
-        expect(findDeployment({ version: '1.2.0' }, _safeDeployments)).toMatchObject(GnosisSafe120);
-        expect(findDeployment({ version: '1.1.1' }, _safeDeployments)).toMatchObject(GnosisSafe111);
-        expect(findDeployment({ version: '1.0.0' }, _safeDeployments)).toMatchObject(GnosisSafe100);
+        expect(findDeployment({ version: '1.3.0' }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe130);
+        expect(findDeployment({ version: '1.2.0' }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe120);
+        expect(findDeployment({ version: '1.1.1' }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe111);
+        expect(findDeployment({ version: '1.0.0' }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe100);
         // Incorrect filter:
-        expect(findDeployment({ version: '2.0.0' }, _safeDeployments)).toBeUndefined();
+        expect(findDeployment({ version: '2.0.0' }, _SAFE_DEPLOYMENTS)).toBeUndefined();
 
         // L2 deployments
-        expect(findDeployment({ version: '1.3.0+L2' }, _safeL2Deployments)).toMatchObject(GnosisSafeL2130);
+        expect(findDeployment({ version: '1.3.0+L2' }, _SAFE_L2_DEPLOYMENTS)).toMatchObject(GnosisSafeL2130);
         // Incorrect filter:
-        expect(findDeployment({ version: '2.0.0+L2' }, _safeL2Deployments)).toBeUndefined();
+        expect(findDeployment({ version: '2.0.0+L2' }, _SAFE_L2_DEPLOYMENTS)).toBeUndefined();
       });
 
       it('should return the correct deployment (filtered by released flag)', () => {
@@ -123,7 +129,7 @@ describe('utils.ts', () => {
         const testDeployments = [testUnreleasedDeploymentJson, testReleasedDeploymentJson];
 
         // Chronological deployments
-        expect(findDeployment({ released: true }, _safeDeployments)).toMatchObject(Safe141);
+        expect(findDeployment({ released: true }, _SAFE_DEPLOYMENTS)).toMatchObject(Safe141);
 
         // Reverse chronological deployments
         expect(findDeployment({ released: true }, _safeDeploymentsReverse)).toMatchObject(GnosisSafe100);
@@ -131,7 +137,7 @@ describe('utils.ts', () => {
         expect(findDeployment({ released: false }, testDeployments)).toMatchObject(testUnreleasedDeployment);
 
         // L2 deployments
-        expect(findDeployment({ released: true }, _safeL2Deployments)).toMatchObject(SafeL2141);
+        expect(findDeployment({ released: true }, _SAFE_L2_DEPLOYMENTS)).toMatchObject(SafeL2141);
       });
 
       it('should return the correct deployment (filtered by network)', () => {
@@ -143,18 +149,18 @@ describe('utils.ts', () => {
         expect(findDeployment({ network: '0' }, _safeDeploymentsReverse)).toBeUndefined();
 
         // L2 deployments
-        expect(findDeployment({ network: '100' }, _safeL2Deployments)).toMatchObject(SafeL2141);
+        expect(findDeployment({ network: '100' }, _SAFE_L2_DEPLOYMENTS)).toMatchObject(SafeL2141);
         // Incorrect filter:
-        expect(findDeployment({ network: '0' }, _safeL2Deployments)).toBeUndefined();
+        expect(findDeployment({ network: '0' }, _SAFE_L2_DEPLOYMENTS)).toBeUndefined();
       });
       it('should return the correct deployment (filtered by version and released)', () => {
         // Chronological deployments
-        expect(findDeployment({ version: '1.3.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe130);
-        expect(findDeployment({ version: '1.2.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe120);
-        expect(findDeployment({ version: '1.1.1', released: true }, _safeDeployments)).toMatchObject(GnosisSafe111);
-        expect(findDeployment({ version: '1.0.0', released: true }, _safeDeployments)).toMatchObject(GnosisSafe100);
+        expect(findDeployment({ version: '1.3.0', released: true }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe130);
+        expect(findDeployment({ version: '1.2.0', released: true }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe120);
+        expect(findDeployment({ version: '1.1.1', released: true }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe111);
+        expect(findDeployment({ version: '1.0.0', released: true }, _SAFE_DEPLOYMENTS)).toMatchObject(GnosisSafe100);
         // Incorrect filter:
-        expect(findDeployment({ version: '1.0.0', released: false }, _safeDeployments)).toBeUndefined();
+        expect(findDeployment({ version: '1.0.0', released: false }, _SAFE_DEPLOYMENTS)).toBeUndefined();
 
         // L2 deployments
         expect(
@@ -163,14 +169,14 @@ describe('utils.ts', () => {
               version: '1.3.0',
               released: true,
             },
-            _safeL2Deployments,
+            _SAFE_L2_DEPLOYMENTS,
           ),
         ).toMatchObject(GnosisSafeL2130);
-        expect(findDeployment({ version: '1.3.0+L2', released: true }, _safeL2Deployments)).toMatchObject(
+        expect(findDeployment({ version: '1.3.0+L2', released: true }, _SAFE_L2_DEPLOYMENTS)).toMatchObject(
           GnosisSafeL2130,
         );
         // Incorrect filter:
-        expect(findDeployment({ version: '1.3.0+L2', released: false }, _safeL2Deployments)).toBeUndefined();
+        expect(findDeployment({ version: '1.3.0+L2', released: false }, _SAFE_L2_DEPLOYMENTS)).toBeUndefined();
       });
       it('should return the correct deployment (filtered by version and network)', () => {
         // Reverse chronological deployments
@@ -220,14 +226,14 @@ describe('utils.ts', () => {
               version: '1.3.0',
               network: '100',
             },
-            _safeL2Deployments,
+            _SAFE_L2_DEPLOYMENTS,
           ),
         ).toMatchObject(GnosisSafeL2130);
-        expect(findDeployment({ version: '1.3.0+L2', network: '100' }, _safeL2Deployments)).toMatchObject(
+        expect(findDeployment({ version: '1.3.0+L2', network: '100' }, _SAFE_L2_DEPLOYMENTS)).toMatchObject(
           GnosisSafeL2130,
         );
         // Incorrect filter:
-        expect(findDeployment({ version: '1.3.0+L2', network: '0' }, _safeL2Deployments)).toBeUndefined();
+        expect(findDeployment({ version: '1.3.0+L2', network: '0' }, _SAFE_L2_DEPLOYMENTS)).toBeUndefined();
       });
       it('should return the correct deployment (filtered by released and network)', () => {
         const testUnreleasedDeploymentJson: SingletonDeploymentJSON = {
@@ -300,9 +306,9 @@ describe('utils.ts', () => {
         );
 
         // L2 deployments
-        expect(findDeployment({ released: true, network: '100' }, _safeL2Deployments)).toMatchObject(SafeL2141);
+        expect(findDeployment({ released: true, network: '100' }, _SAFE_L2_DEPLOYMENTS)).toMatchObject(SafeL2141);
         // Incorrect filter:
-        expect(findDeployment({ released: true, network: '0' }, _safeL2Deployments)).toBeUndefined();
+        expect(findDeployment({ released: true, network: '0' }, _SAFE_L2_DEPLOYMENTS)).toBeUndefined();
         expect(findDeployment({ released: false, network: '100' }, testDeployments)).toBeUndefined();
       });
       it('should return the correct deployment (filtered by version, released and network)', () => {
@@ -338,21 +344,21 @@ describe('utils.ts', () => {
               released: true,
               network: '100',
             },
-            _safeL2Deployments,
+            _SAFE_L2_DEPLOYMENTS,
           ),
         ).toMatchObject(GnosisSafeL2130);
         expect(
-          findDeployment({ version: '1.3.0+L2', released: true, network: '100' }, _safeL2Deployments),
+          findDeployment({ version: '1.3.0+L2', released: true, network: '100' }, _SAFE_L2_DEPLOYMENTS),
         ).toMatchObject(GnosisSafeL2130);
         // Incorrect filter:
         expect(
-          findDeployment({ version: '1.3.0+L2', released: false, network: '100' }, _safeL2Deployments),
+          findDeployment({ version: '1.3.0+L2', released: false, network: '100' }, _SAFE_L2_DEPLOYMENTS),
         ).toBeUndefined();
         expect(
-          findDeployment({ version: '1.3.0+L2', released: true, network: '0' }, _safeL2Deployments),
+          findDeployment({ version: '1.3.0+L2', released: true, network: '0' }, _SAFE_L2_DEPLOYMENTS),
         ).toBeUndefined();
         expect(
-          findDeployment({ version: '2.0.0+L2', released: true, network: '100' }, _safeL2Deployments),
+          findDeployment({ version: '2.0.0+L2', released: true, network: '100' }, _SAFE_L2_DEPLOYMENTS),
         ).toBeUndefined();
       });
     });
@@ -362,26 +368,44 @@ describe('utils.ts', () => {
         const testReleasedDeploymentJson: SingletonDeploymentJSON = {
           version: '',
           abi: [],
-          addresses: {
-            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-            eip155: '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe',
-            zksync: '0xbabebabebabebabebabebabebabebabebabebabe',
+          deployments: {
+            canonical: {
+              address: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+            eip155: {
+              address: '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+            zksync: {
+              address: '0xbabebabebabebabebabebabebabebabebabebabe',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
           },
           networkAddresses: { '1': 'canonical', '100': 'zksync', '101': ['canonical', 'eip155'] },
           contractName: '',
-          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           released: true, // Default filter value
         };
         const expectedDeployment: SingletonDeploymentV2 = {
-          addresses: {
-            canonical: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          deployments: {
+            canonical: {
+              address: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+            eip155: {
+              address: '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+            zksync: {
+              address: '0xbabebabebabebabebabebabebabebabebabebabe',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
           },
           networkAddresses: {
             '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
             '100': '0xbabebabebabebabebabebabebabebabebabebabe',
             '101': ['0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef', '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe'],
           },
-          codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           released: true,
           abi: [],
           version: '',

--- a/src/accessors.ts
+++ b/src/accessors.ts
@@ -1,20 +1,6 @@
-import SimulateTxAccessor130 from './assets/v1.3.0/simulate_tx_accessor.json';
-import SimulateTxAccessor141 from './assets/v1.4.1/simulate_tx_accessor.json';
-
-import {
-  DeploymentFilter,
-  SingletonDeploymentJSON,
-  SingletonDeployment,
-  DeploymentFormats,
-  SingletonDeploymentV2,
-} from './types';
+import { DeploymentFilter, SingletonDeployment, DeploymentFormats, SingletonDeploymentV2 } from './types';
 import { findDeployment } from './utils';
-
-// This is a sorted array (newest to oldest)
-const accessorDeployments: SingletonDeploymentJSON[] = [
-  SimulateTxAccessor141 as SingletonDeploymentJSON,
-  SimulateTxAccessor130 as SingletonDeploymentJSON,
-];
+import { _ACCESSOR_DEPLOYMENTS } from './deployments';
 
 /**
  * Retrieves a single simulate transaction accessor deployment based on the provided filter.
@@ -23,7 +9,7 @@ const accessorDeployments: SingletonDeploymentJSON[] = [
  * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
  */
 export const getSimulateTxAccessorDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, accessorDeployments);
+  return findDeployment(filter, _ACCESSOR_DEPLOYMENTS);
 };
 
 /**
@@ -33,5 +19,5 @@ export const getSimulateTxAccessorDeployment = (filter?: DeploymentFilter): Sing
  * @returns {SingletonDeploymentV2 | undefined} - The found deployments in the specified format or undefined if no deployments match the filter.
  */
 export const getSimulateTxAccessorDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, accessorDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _ACCESSOR_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };

--- a/src/accessors.ts
+++ b/src/accessors.ts
@@ -13,10 +13,22 @@ import { findDeployment } from './utils';
 // This is a sorted array (newest to oldest)
 const accessorDeployments: SingletonDeploymentJSON[] = [SimulateTxAccessor141, SimulateTxAccessor130];
 
+/**
+ * Retrieves a single simulate transaction accessor deployment based on the provided filter.
+ *
+ * @param {DeploymentFilter} [filter] - Optional filter to apply when searching for the deployment.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
+ */
 export const getSimulateTxAccessorDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, accessorDeployments);
 };
 
+/**
+ * Retrieves multiple simulate transaction accessor deployments based on the provided filter.
+ *
+ * @param {DeploymentFilter} [filter] - Optional filter to apply when searching for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The found deployments in the specified format or undefined if no deployments match the filter.
+ */
 export const getSimulateTxAccessorDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, accessorDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/accessors.ts
+++ b/src/accessors.ts
@@ -1,7 +1,13 @@
 import SimulateTxAccessor130 from './assets/v1.3.0/simulate_tx_accessor.json';
 import SimulateTxAccessor141 from './assets/v1.4.1/simulate_tx_accessor.json';
 
-import { DeploymentFilter, SingletonDeploymentJSON, SingletonDeployment } from './types';
+import {
+  DeploymentFilter,
+  SingletonDeploymentJSON,
+  SingletonDeployment,
+  DeploymentFormats,
+  SingletonDeploymentV2,
+} from './types';
 import { findDeployment } from './utils';
 
 // This is a sorted array (newest to oldest)
@@ -9,4 +15,8 @@ const accessorDeployments: SingletonDeploymentJSON[] = [SimulateTxAccessor141, S
 
 export const getSimulateTxAccessorDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, accessorDeployments);
+};
+
+export const getSimulateTxAccessorDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, accessorDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,0 +1,90 @@
+import { SingletonDeploymentJSON } from './types';
+
+// This is a file where all the deployments are consolidated
+// We do it in a separate file so we don't have to repeat comments about the array order and the type casting.
+// We use some specific types (like `AddressType`) in the `SingletonDeploymentJSON` type, but the TypeScript cannot infer that from the JSON files.
+// So we need to cast them to `SingletonDeploymentJSON` manually. The casting is valid because we have a test in `__tests__/assets.test.ts` that checks that the JSON files are valid.
+// The arrays are sorted by preference, which at the moment means from the most recent version to the oldest.
+// The arrays are prefixed with an underscore because they are not meant to be imported directly.
+
+import SimulateTxAccessor130 from './assets/v1.3.0/simulate_tx_accessor.json';
+import SimulateTxAccessor141 from './assets/v1.4.1/simulate_tx_accessor.json';
+
+const _ACCESSOR_DEPLOYMENTS = [SimulateTxAccessor141, SimulateTxAccessor130] as SingletonDeploymentJSON[];
+
+import ProxyFactory100 from './assets/v1.0.0/proxy_factory.json';
+import ProxyFactory111 from './assets/v1.1.1/proxy_factory.json';
+import ProxyFactory130 from './assets/v1.3.0/proxy_factory.json';
+import SafeProxyFactory141 from './assets/v1.4.1/safe_proxy_factory.json';
+
+const _FACTORY_DEPLOYMENTS = [
+  SafeProxyFactory141,
+  ProxyFactory130,
+  ProxyFactory111,
+  ProxyFactory100,
+] as SingletonDeploymentJSON[];
+
+import DefaultCallbackHandler130 from './assets/v1.1.1/default_callback_handler.json';
+
+const _DEFAULT_CALLBACK_HANDLER_DEPLOYMENTS = [DefaultCallbackHandler130] as SingletonDeploymentJSON[];
+
+import CompatibilityFallbackHandler130 from './assets/v1.3.0/compatibility_fallback_handler.json';
+import CompatibilityFallbackHandler141 from './assets/v1.4.1/compatibility_fallback_handler.json';
+
+const _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS = [
+  CompatibilityFallbackHandler141,
+  CompatibilityFallbackHandler130,
+] as SingletonDeploymentJSON[];
+
+import Safe141 from './assets/v1.4.1/safe.json';
+import GnosisSafe130 from './assets/v1.3.0/gnosis_safe.json';
+import GnosisSafe120 from './assets/v1.2.0/gnosis_safe.json';
+import GnosisSafe111 from './assets/v1.1.1/gnosis_safe.json';
+import GnosisSafe100 from './assets/v1.0.0/gnosis_safe.json';
+
+const _SAFE_DEPLOYMENTS = [
+  Safe141,
+  GnosisSafe130,
+  GnosisSafe120,
+  GnosisSafe111,
+  GnosisSafe100,
+] as SingletonDeploymentJSON[];
+
+import SafeL2141 from './assets/v1.4.1/safe_l2.json';
+import GnosisSafeL2130 from './assets/v1.3.0/gnosis_safe_l2.json';
+
+const _SAFE_L2_DEPLOYMENTS = [SafeL2141, GnosisSafeL2130] as SingletonDeploymentJSON[];
+
+import MultiSend111 from './assets/v1.1.1/multi_send.json';
+import MultiSend130 from './assets/v1.3.0/multi_send.json';
+import MultiSend141 from './assets/v1.4.1/multi_send.json';
+
+const _MULTI_SEND_DEPLOYMENTS = [MultiSend141, MultiSend130, MultiSend111] as SingletonDeploymentJSON[];
+
+import MultiSendCallOnly130 from './assets/v1.3.0/multi_send_call_only.json';
+import MultiSendCallOnly141 from './assets/v1.4.1/multi_send_call_only.json';
+
+const _MULTI_SEND_CALL_ONLY_DEPLOYMENTS = [MultiSendCallOnly141, MultiSendCallOnly130] as SingletonDeploymentJSON[];
+
+import CreateCall130 from './assets/v1.3.0/create_call.json';
+import CreateCall141 from './assets/v1.4.1/create_call.json';
+
+const _CREATE_CALL_DEPLOYMENTS = [CreateCall141, CreateCall130] as SingletonDeploymentJSON[];
+
+import SignMessageLib130 from './assets/v1.3.0/sign_message_lib.json';
+import SignMessageLib141 from './assets/v1.4.1/sign_message_lib.json';
+
+const _SIGN_MESSAGE_LIB_DEPLOYMENTS = [SignMessageLib141, SignMessageLib130] as SingletonDeploymentJSON[];
+
+export {
+  _ACCESSOR_DEPLOYMENTS,
+  _FACTORY_DEPLOYMENTS,
+  _DEFAULT_CALLBACK_HANDLER_DEPLOYMENTS,
+  _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS,
+  _SAFE_DEPLOYMENTS,
+  _SAFE_L2_DEPLOYMENTS,
+  _MULTI_SEND_DEPLOYMENTS,
+  _MULTI_SEND_CALL_ONLY_DEPLOYMENTS,
+  _CREATE_CALL_DEPLOYMENTS,
+  _SIGN_MESSAGE_LIB_DEPLOYMENTS,
+};

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -20,10 +20,20 @@ const factoryDeployments: SingletonDeploymentJSON[] = [
   ProxyFactory100,
 ];
 
+/**
+ * Finds the latest proxy factory deployment that matches the given filter.
+ * @param {DeploymentFilter} [filter] - The filter to apply when searching for the deployment.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
+ */
 export const getProxyFactoryDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, factoryDeployments);
 };
 
+/**
+ * Finds all proxy factory deployments that match the given filter.
+ * @param {DeploymentFilter} [filter] - The filter to apply when searching for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The found deployments or undefined if no deployments match the filter.
+ */
 export const getProxyFactoryDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, factoryDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -3,7 +3,13 @@ import ProxyFactory111 from './assets/v1.1.1/proxy_factory.json';
 import ProxyFactory130 from './assets/v1.3.0/proxy_factory.json';
 import SafeProxyFactory141 from './assets/v1.4.1/safe_proxy_factory.json';
 
-import { DeploymentFilter, SingletonDeployment, SingletonDeploymentJSON } from './types';
+import {
+  DeploymentFilter,
+  DeploymentFormats,
+  SingletonDeployment,
+  SingletonDeploymentJSON,
+  SingletonDeploymentV2,
+} from './types';
 import { findDeployment } from './utils';
 
 // This is a sorted array (newest to oldest)
@@ -16,4 +22,8 @@ const factoryDeployments: SingletonDeploymentJSON[] = [
 
 export const getProxyFactoryDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, factoryDeployments);
+};
+
+export const getProxyFactoryDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, factoryDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -1,24 +1,6 @@
-import ProxyFactory100 from './assets/v1.0.0/proxy_factory.json';
-import ProxyFactory111 from './assets/v1.1.1/proxy_factory.json';
-import ProxyFactory130 from './assets/v1.3.0/proxy_factory.json';
-import SafeProxyFactory141 from './assets/v1.4.1/safe_proxy_factory.json';
-
-import {
-  DeploymentFilter,
-  DeploymentFormats,
-  SingletonDeployment,
-  SingletonDeploymentJSON,
-  SingletonDeploymentV2,
-} from './types';
+import { DeploymentFilter, DeploymentFormats, SingletonDeployment, SingletonDeploymentV2 } from './types';
 import { findDeployment } from './utils';
-
-// This is a sorted array (newest to oldest)
-const factoryDeployments: SingletonDeploymentJSON[] = [
-  SafeProxyFactory141,
-  ProxyFactory130,
-  ProxyFactory111,
-  ProxyFactory100,
-];
+import { _FACTORY_DEPLOYMENTS } from './deployments';
 
 /**
  * Finds the latest proxy factory deployment that matches the given filter.
@@ -26,7 +8,7 @@ const factoryDeployments: SingletonDeploymentJSON[] = [
  * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
  */
 export const getProxyFactoryDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, factoryDeployments);
+  return findDeployment(filter, _FACTORY_DEPLOYMENTS);
 };
 
 /**
@@ -35,5 +17,5 @@ export const getProxyFactoryDeployment = (filter?: DeploymentFilter): SingletonD
  * @returns {SingletonDeploymentV2 | undefined} - The found deployments or undefined if no deployments match the filter.
  */
 export const getProxyFactoryDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, factoryDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _FACTORY_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,17 +1,6 @@
-import DefaultCallbackHandler130 from './assets/v1.1.1/default_callback_handler.json';
-import CompatibilityFallbackHandler130 from './assets/v1.3.0/compatibility_fallback_handler.json';
-import CompatibilityFallbackHandler141 from './assets/v1.4.1/compatibility_fallback_handler.json';
-import {
-  DeploymentFilter,
-  DeploymentFormats,
-  SingletonDeployment,
-  SingletonDeploymentJSON,
-  SingletonDeploymentV2,
-} from './types';
+import { DeploymentFilter, DeploymentFormats, SingletonDeployment, SingletonDeploymentV2 } from './types';
 import { findDeployment } from './utils';
-
-// This is a sorted array (by preference)
-const defaultCallbackHandlerDeployments: SingletonDeploymentJSON[] = [DefaultCallbackHandler130];
+import { _DEFAULT_CALLBACK_HANDLER_DEPLOYMENTS, _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS } from './deployments';
 
 /**
  * Get the default callback handler deployment based on the provided filter.
@@ -19,18 +8,17 @@ const defaultCallbackHandlerDeployments: SingletonDeploymentJSON[] = [DefaultCal
  * @returns {SingletonDeployment | undefined} - The found deployment or undefined if not found.
  */
 export const getDefaultCallbackHandlerDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, defaultCallbackHandlerDeployments);
+  return findDeployment(filter, _DEFAULT_CALLBACK_HANDLER_DEPLOYMENTS);
 };
 
+/**
+ * Get all default callback handler deployments based on the provided filter.
+ * @param {DeploymentFilter} [filter] - Optional filter to apply to the deployment search.
+ * @returns {SingletonDeploymentV2 | undefined} - The found deployments in version 2 format or undefined if not found.
+ */
 export const getDefaultCallbackHandlerDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, defaultCallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _DEFAULT_CALLBACK_HANDLER_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };
-
-// This is a sorted array (by preference)
-const compatFallbackHandlerDeployments: SingletonDeploymentJSON[] = [
-  CompatibilityFallbackHandler141,
-  CompatibilityFallbackHandler130,
-];
 
 /**
  * Get the compatibility fallback handler deployment based on the provided filter.
@@ -40,7 +28,7 @@ const compatFallbackHandlerDeployments: SingletonDeploymentJSON[] = [
 export const getCompatibilityFallbackHandlerDeployment = (
   filter?: DeploymentFilter,
 ): SingletonDeployment | undefined => {
-  return findDeployment(filter, compatFallbackHandlerDeployments);
+  return findDeployment(filter, _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS);
 };
 
 /**
@@ -51,7 +39,7 @@ export const getCompatibilityFallbackHandlerDeployment = (
 export const getCompatibilityFallbackHandlerDeployments = (
   filter?: DeploymentFilter,
 ): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, compatFallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };
 
 /**
@@ -61,3 +49,20 @@ export const getCompatibilityFallbackHandlerDeployments = (
  * @returns {SingletonDeployment | undefined} - The found deployment or undefined if not found.
  */
 export const getFallbackHandlerDeployment = getCompatibilityFallbackHandlerDeployment;
+// Leaving the comment here so it's not a part of the JSDoc
+// Previously, the function code was this:
+// // This is a sorted array (by preference)
+// const fallbackHandlerDeployments: SingletonDeploymentJSON[] = [
+//   CompatibilityFallbackHandler141,
+//   CompatibilityFallbackHandler130,
+//   DefaultCallbackHandler130,
+// ];
+// export const getFallbackHandlerDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
+//   return findDeployment(filter, fallbackHandlerDeployments);
+// };
+// The problem with the function is that there’s no possible filter that would make the function return the last element of the array
+// (DefaultCallbackHandler130 ), since we only allow to filter by version, networks and released flag. The only possible way is to have
+// the default callback handler deployed to a network where the compatibility fallback handler isn’t deployed, but we require the whole
+// suite of the contracts be deployed to a network.
+// Since we didn't want to enforce a preferred fallback handler on the deployments package level,
+// we decided to alias it to getCompatibilityFallbackHandlerDeployment (previously returned value)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,8 +13,17 @@ import { findDeployment } from './utils';
 // This is a sorted array (by preference)
 const defaultCallbackHandlerDeployments: SingletonDeploymentJSON[] = [DefaultCallbackHandler130];
 
+/**
+ * Get the default callback handler deployment based on the provided filter.
+ * @param {DeploymentFilter} [filter] - Optional filter to apply to the deployment search.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if not found.
+ */
 export const getDefaultCallbackHandlerDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, defaultCallbackHandlerDeployments);
+};
+
+export const getDefaultCallbackHandlerDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, defaultCallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
 };
 
 // This is a sorted array (by preference)
@@ -23,29 +32,32 @@ const compatFallbackHandlerDeployments: SingletonDeploymentJSON[] = [
   CompatibilityFallbackHandler130,
 ];
 
+/**
+ * Get the compatibility fallback handler deployment based on the provided filter.
+ * @param {DeploymentFilter} [filter] - Optional filter to apply to the deployment search.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if not found.
+ */
 export const getCompatibilityFallbackHandlerDeployment = (
   filter?: DeploymentFilter,
 ): SingletonDeployment | undefined => {
   return findDeployment(filter, compatFallbackHandlerDeployments);
 };
 
-export const getCompatibilityFallbackHandlerDeploymentV2 = (
+/**
+ * Get all compatibility fallback handler deployments based on the provided filter.
+ * @param {DeploymentFilter} [filter] - Optional filter to apply to the deployment search.
+ * @returns {SingletonDeploymentV2 | undefined} - The found deployments in version 2 format or undefined if not found.
+ */
+export const getCompatibilityFallbackHandlerDeployments = (
   filter?: DeploymentFilter,
 ): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, compatFallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
 };
 
-// This is a sorted array (by preference)
-const fallbackHandlerDeployments: SingletonDeploymentJSON[] = [
-  CompatibilityFallbackHandler141,
-  CompatibilityFallbackHandler130,
-  DefaultCallbackHandler130,
-];
-
-export const getFallbackHandlerDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, fallbackHandlerDeployments);
-};
-
-export const getFallbackHandlerDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, fallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
-};
+/**
+ * Get the fallback handler deployment based on the provided filter. This method is an alias for `getCompatibilityFallbackHandlerDeployment`.
+ * Kept for backwards compatibility.
+ * @param {DeploymentFilter} [filter] - Optional filter to apply to the deployment search.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if not found.
+ */
+export const getFallbackHandlerDeployment = getCompatibilityFallbackHandlerDeployment;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,7 +1,13 @@
 import DefaultCallbackHandler130 from './assets/v1.1.1/default_callback_handler.json';
 import CompatibilityFallbackHandler130 from './assets/v1.3.0/compatibility_fallback_handler.json';
 import CompatibilityFallbackHandler141 from './assets/v1.4.1/compatibility_fallback_handler.json';
-import { DeploymentFilter, SingletonDeployment, SingletonDeploymentJSON } from './types';
+import {
+  DeploymentFilter,
+  DeploymentFormats,
+  SingletonDeployment,
+  SingletonDeploymentJSON,
+  SingletonDeploymentV2,
+} from './types';
 import { findDeployment } from './utils';
 
 // This is a sorted array (by preference)
@@ -23,6 +29,12 @@ export const getCompatibilityFallbackHandlerDeployment = (
   return findDeployment(filter, compatFallbackHandlerDeployments);
 };
 
+export const getCompatibilityFallbackHandlerDeploymentV2 = (
+  filter?: DeploymentFilter,
+): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, compatFallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
+};
+
 // This is a sorted array (by preference)
 const fallbackHandlerDeployments: SingletonDeploymentJSON[] = [
   CompatibilityFallbackHandler141,
@@ -32,4 +44,8 @@ const fallbackHandlerDeployments: SingletonDeploymentJSON[] = [
 
 export const getFallbackHandlerDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, fallbackHandlerDeployments);
+};
+
+export const getFallbackHandlerDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, fallbackHandlerDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -1,23 +1,11 @@
-import CreateCall130 from './assets/v1.3.0/create_call.json';
-import CreateCall141 from './assets/v1.4.1/create_call.json';
-import MultiSend111 from './assets/v1.1.1/multi_send.json';
-import MultiSend130 from './assets/v1.3.0/multi_send.json';
-import MultiSend141 from './assets/v1.4.1/multi_send.json';
-import MultiSendCallOnly130 from './assets/v1.3.0/multi_send_call_only.json';
-import MultiSendCallOnly141 from './assets/v1.4.1/multi_send_call_only.json';
-import SignMessageLib130 from './assets/v1.3.0/sign_message_lib.json';
-import SignMessageLib141 from './assets/v1.4.1/sign_message_lib.json';
 import {
-  DeploymentFilter,
-  DeploymentFormats,
-  SingletonDeployment,
-  SingletonDeploymentJSON,
-  SingletonDeploymentV2,
-} from './types';
+  _CREATE_CALL_DEPLOYMENTS,
+  _MULTI_SEND_CALL_ONLY_DEPLOYMENTS,
+  _MULTI_SEND_DEPLOYMENTS,
+  _SIGN_MESSAGE_LIB_DEPLOYMENTS,
+} from './deployments';
+import { DeploymentFilter, DeploymentFormats, SingletonDeployment, SingletonDeploymentV2 } from './types';
 import { findDeployment } from './utils';
-
-// This is a sorted array (by preference, currently we use 111 in most cases)
-const multiSendDeployments: SingletonDeploymentJSON[] = [MultiSend141, MultiSend130, MultiSend111];
 
 /**
  * Get the MultiSend deployment based on the provided filter.
@@ -25,7 +13,7 @@ const multiSendDeployments: SingletonDeploymentJSON[] = [MultiSend141, MultiSend
  * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
  */
 export const getMultiSendDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, multiSendDeployments);
+  return findDeployment(filter, _MULTI_SEND_DEPLOYMENTS);
 };
 
 /**
@@ -34,11 +22,8 @@ export const getMultiSendDeployment = (filter?: DeploymentFilter): SingletonDepl
  * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
  */
 export const getMultiSendDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, multiSendDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _MULTI_SEND_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };
-
-// This is a sorted array (by preference)
-const multiSendCallOnlyDeployments: SingletonDeploymentJSON[] = [MultiSendCallOnly141, MultiSendCallOnly130];
 
 /**
  * Get the MultiSendCallOnly deployment based on the provided filter.
@@ -46,7 +31,7 @@ const multiSendCallOnlyDeployments: SingletonDeploymentJSON[] = [MultiSendCallOn
  * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
  */
 export const getMultiSendCallOnlyDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, multiSendCallOnlyDeployments);
+  return findDeployment(filter, _MULTI_SEND_CALL_ONLY_DEPLOYMENTS);
 };
 
 /**
@@ -55,11 +40,8 @@ export const getMultiSendCallOnlyDeployment = (filter?: DeploymentFilter): Singl
  * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
  */
 export const getMultiSendCallOnlyDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, multiSendCallOnlyDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _MULTI_SEND_CALL_ONLY_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };
-
-// This is a sorted array (by preference)
-const createCallDeployments: SingletonDeploymentJSON[] = [CreateCall141, CreateCall130];
 
 /**
  * Get the CreateCall deployment based on the provided filter.
@@ -67,7 +49,7 @@ const createCallDeployments: SingletonDeploymentJSON[] = [CreateCall141, CreateC
  * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
  */
 export const getCreateCallDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, createCallDeployments);
+  return findDeployment(filter, _CREATE_CALL_DEPLOYMENTS);
 };
 
 /**
@@ -76,10 +58,8 @@ export const getCreateCallDeployment = (filter?: DeploymentFilter): SingletonDep
  * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
  */
 export const getCreateCallDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, createCallDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _CREATE_CALL_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };
-
-const signMessageLibDeployments: SingletonDeploymentJSON[] = [SignMessageLib141, SignMessageLib130];
 
 /**
  * Get the SignMessageLib deployment based on the provided filter.
@@ -87,7 +67,7 @@ const signMessageLibDeployments: SingletonDeploymentJSON[] = [SignMessageLib141,
  * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
  */
 export const getSignMessageLibDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, signMessageLibDeployments);
+  return findDeployment(filter, _SIGN_MESSAGE_LIB_DEPLOYMENTS);
 };
 
 /**
@@ -96,5 +76,5 @@ export const getSignMessageLibDeployment = (filter?: DeploymentFilter): Singleto
  * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
  */
 export const getSignMessageLibDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, signMessageLibDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _SIGN_MESSAGE_LIB_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -19,10 +19,20 @@ import { findDeployment } from './utils';
 // This is a sorted array (by preference, currently we use 111 in most cases)
 const multiSendDeployments: SingletonDeploymentJSON[] = [MultiSend141, MultiSend130, MultiSend111];
 
+/**
+ * Get the MultiSend deployment based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployment.
+ * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
+ */
 export const getMultiSendDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, multiSendDeployments);
 };
 
+/**
+ * Get all MultiSend deployments based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
+ */
 export const getMultiSendDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, multiSendDeployments, DeploymentFormats.MULTIPLE);
 };
@@ -30,10 +40,20 @@ export const getMultiSendDeployments = (filter?: DeploymentFilter): SingletonDep
 // This is a sorted array (by preference)
 const multiSendCallOnlyDeployments: SingletonDeploymentJSON[] = [MultiSendCallOnly141, MultiSendCallOnly130];
 
+/**
+ * Get the MultiSendCallOnly deployment based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployment.
+ * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
+ */
 export const getMultiSendCallOnlyDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, multiSendCallOnlyDeployments);
 };
 
+/**
+ * Get all MultiSendCallOnly deployments based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
+ */
 export const getMultiSendCallOnlyDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, multiSendCallOnlyDeployments, DeploymentFormats.MULTIPLE);
 };
@@ -41,20 +61,40 @@ export const getMultiSendCallOnlyDeployments = (filter?: DeploymentFilter): Sing
 // This is a sorted array (by preference)
 const createCallDeployments: SingletonDeploymentJSON[] = [CreateCall141, CreateCall130];
 
+/**
+ * Get the CreateCall deployment based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployment.
+ * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
+ */
 export const getCreateCallDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, createCallDeployments);
 };
 
+/**
+ * Get all CreateCall deployments based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
+ */
 export const getCreateCallDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, createCallDeployments, DeploymentFormats.MULTIPLE);
 };
 
 const signMessageLibDeployments: SingletonDeploymentJSON[] = [SignMessageLib141, SignMessageLib130];
 
+/**
+ * Get the SignMessageLib deployment based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployment.
+ * @returns {SingletonDeployment | undefined} - The matched deployment or undefined if not found.
+ */
 export const getSignMessageLibDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, signMessageLibDeployments);
 };
 
+/**
+ * Get all SignMessageLib deployments based on the provided filter.
+ * @param {DeploymentFilter} [filter] - The filter criteria for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The matched deployments or undefined if not found.
+ */
 export const getSignMessageLibDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
   return findDeployment(filter, signMessageLibDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -7,7 +7,13 @@ import MultiSendCallOnly130 from './assets/v1.3.0/multi_send_call_only.json';
 import MultiSendCallOnly141 from './assets/v1.4.1/multi_send_call_only.json';
 import SignMessageLib130 from './assets/v1.3.0/sign_message_lib.json';
 import SignMessageLib141 from './assets/v1.4.1/sign_message_lib.json';
-import { DeploymentFilter, SingletonDeployment, SingletonDeploymentJSON } from './types';
+import {
+  DeploymentFilter,
+  DeploymentFormats,
+  SingletonDeployment,
+  SingletonDeploymentJSON,
+  SingletonDeploymentV2,
+} from './types';
 import { findDeployment } from './utils';
 
 // This is a sorted array (by preference, currently we use 111 in most cases)
@@ -17,11 +23,19 @@ export const getMultiSendDeployment = (filter?: DeploymentFilter): SingletonDepl
   return findDeployment(filter, multiSendDeployments);
 };
 
+export const getMultiSendDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, multiSendDeployments, DeploymentFormats.MULTIPLE);
+};
+
 // This is a sorted array (by preference)
 const multiSendCallOnlyDeployments: SingletonDeploymentJSON[] = [MultiSendCallOnly141, MultiSendCallOnly130];
 
 export const getMultiSendCallOnlyDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, multiSendCallOnlyDeployments);
+};
+
+export const getMultiSendCallOnlyDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, multiSendCallOnlyDeployments, DeploymentFormats.MULTIPLE);
 };
 
 // This is a sorted array (by preference)
@@ -31,8 +45,16 @@ export const getCreateCallDeployment = (filter?: DeploymentFilter): SingletonDep
   return findDeployment(filter, createCallDeployments);
 };
 
+export const getCreateCallDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, createCallDeployments, DeploymentFormats.MULTIPLE);
+};
+
 const signMessageLibDeployments: SingletonDeploymentJSON[] = [SignMessageLib141, SignMessageLib130];
 
 export const getSignMessageLibDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, signMessageLibDeployments);
+};
+
+export const getSignMessageLibDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, signMessageLibDeployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/safes.ts
+++ b/src/safes.ts
@@ -17,13 +17,13 @@ export const _safeDeployments: SingletonDeploymentJSON[] = [
   GnosisSafe100,
 ];
 
-export const getSafeSingletonDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
+export const getSafeSingletonDeployment = (filter?: DeploymentFilter) => {
   return findDeployment(filter, _safeDeployments);
 };
 
 // This is a sorted array (newest to oldest), exported for tests
 export const _safeL2Deployments: SingletonDeploymentJSON[] = [SafeL2141, GnosisSafeL2130];
 
-export const getSafeL2SingletonDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
+export const getSafeL2SingletonDeployment = (filter?: DeploymentFilter) => {
   return findDeployment(filter, _safeL2Deployments);
 };

--- a/src/safes.ts
+++ b/src/safes.ts
@@ -5,7 +5,13 @@ import GnosisSafe130 from './assets/v1.3.0/gnosis_safe.json';
 import GnosisSafe120 from './assets/v1.2.0/gnosis_safe.json';
 import GnosisSafe111 from './assets/v1.1.1/gnosis_safe.json';
 import GnosisSafe100 from './assets/v1.0.0/gnosis_safe.json';
-import { DeploymentFilter, SingletonDeployment, SingletonDeploymentJSON } from './types';
+import {
+  DeploymentFilter,
+  DeploymentFormats,
+  SingletonDeployment,
+  SingletonDeploymentV2,
+  SingletonDeploymentJSON,
+} from './types';
 import { findDeployment } from './utils';
 
 // This is a sorted array (newest to oldest), exported for tests
@@ -17,13 +23,41 @@ export const _safeDeployments: SingletonDeploymentJSON[] = [
   GnosisSafe100,
 ];
 
-export const getSafeSingletonDeployment = (filter?: DeploymentFilter) => {
+/**
+ * Finds the latest safe singleton deployment that matches the given filter.
+ * @param {DeploymentFilter} [filter] - The filter to apply when searching for the deployment.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
+ */
+export const getSafeSingletonDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, _safeDeployments);
+};
+
+/**
+ * Finds all safe singleton deployments that match the given filter.
+ * @param {DeploymentFilter} [filter] - The filter to apply when searching for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The found deployments or undefined if no deployments match the filter.
+ */
+export const getSafeSingletonDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, _safeDeployments, DeploymentFormats.MULTIPLE);
 };
 
 // This is a sorted array (newest to oldest), exported for tests
 export const _safeL2Deployments: SingletonDeploymentJSON[] = [SafeL2141, GnosisSafeL2130];
 
-export const getSafeL2SingletonDeployment = (filter?: DeploymentFilter) => {
+/**
+ * Finds the latest safe L2 singleton deployment that matches the given filter.
+ * @param {DeploymentFilter} [filter] - The filter to apply when searching for the deployment.
+ * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
+ */
+export const getSafeL2SingletonDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
   return findDeployment(filter, _safeL2Deployments);
+};
+
+/**
+ * Finds all safe L2 singleton deployments that match the given filter.
+ * @param {DeploymentFilter} [filter] - The filter to apply when searching for the deployments.
+ * @returns {SingletonDeploymentV2 | undefined} - The found deployments or undefined if no deployments match the filter.
+ */
+export const getSafeL2SingletonDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
+  return findDeployment(filter, _safeL2Deployments, DeploymentFormats.MULTIPLE);
 };

--- a/src/safes.ts
+++ b/src/safes.ts
@@ -1,27 +1,6 @@
-import SafeL2141 from './assets/v1.4.1/safe_l2.json';
-import Safe141 from './assets/v1.4.1/safe.json';
-import GnosisSafeL2130 from './assets/v1.3.0/gnosis_safe_l2.json';
-import GnosisSafe130 from './assets/v1.3.0/gnosis_safe.json';
-import GnosisSafe120 from './assets/v1.2.0/gnosis_safe.json';
-import GnosisSafe111 from './assets/v1.1.1/gnosis_safe.json';
-import GnosisSafe100 from './assets/v1.0.0/gnosis_safe.json';
-import {
-  DeploymentFilter,
-  DeploymentFormats,
-  SingletonDeployment,
-  SingletonDeploymentV2,
-  SingletonDeploymentJSON,
-} from './types';
+import { _SAFE_DEPLOYMENTS, _SAFE_L2_DEPLOYMENTS } from './deployments';
+import { DeploymentFilter, DeploymentFormats, SingletonDeployment, SingletonDeploymentV2 } from './types';
 import { findDeployment } from './utils';
-
-// This is a sorted array (newest to oldest), exported for tests
-export const _safeDeployments: SingletonDeploymentJSON[] = [
-  Safe141,
-  GnosisSafe130,
-  GnosisSafe120,
-  GnosisSafe111,
-  GnosisSafe100,
-];
 
 /**
  * Finds the latest safe singleton deployment that matches the given filter.
@@ -29,7 +8,7 @@ export const _safeDeployments: SingletonDeploymentJSON[] = [
  * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
  */
 export const getSafeSingletonDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, _safeDeployments);
+  return findDeployment(filter, _SAFE_DEPLOYMENTS);
 };
 
 /**
@@ -38,11 +17,8 @@ export const getSafeSingletonDeployment = (filter?: DeploymentFilter): Singleton
  * @returns {SingletonDeploymentV2 | undefined} - The found deployments or undefined if no deployments match the filter.
  */
 export const getSafeSingletonDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, _safeDeployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _SAFE_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };
-
-// This is a sorted array (newest to oldest), exported for tests
-export const _safeL2Deployments: SingletonDeploymentJSON[] = [SafeL2141, GnosisSafeL2130];
 
 /**
  * Finds the latest safe L2 singleton deployment that matches the given filter.
@@ -50,7 +26,7 @@ export const _safeL2Deployments: SingletonDeploymentJSON[] = [SafeL2141, GnosisS
  * @returns {SingletonDeployment | undefined} - The found deployment or undefined if no deployment matches the filter.
  */
 export const getSafeL2SingletonDeployment = (filter?: DeploymentFilter): SingletonDeployment | undefined => {
-  return findDeployment(filter, _safeL2Deployments);
+  return findDeployment(filter, _SAFE_L2_DEPLOYMENTS);
 };
 
 /**
@@ -59,5 +35,5 @@ export const getSafeL2SingletonDeployment = (filter?: DeploymentFilter): Singlet
  * @returns {SingletonDeploymentV2 | undefined} - The found deployments or undefined if no deployments match the filter.
  */
 export const getSafeL2SingletonDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
-  return findDeployment(filter, _safeL2Deployments, DeploymentFormats.MULTIPLE);
+  return findDeployment(filter, _SAFE_L2_DEPLOYMENTS, DeploymentFormats.MULTIPLE);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export interface SingletonDeployment {
   // 1.3.0: canonical, eip155, zksync
   // 1.4.1: canonical, zksync
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
-  deployments: AtLeastOne<Record<AddressType, Record<'address' | 'codeHash', string>>>;
+  deployments: AtLeastOne<Record<AddressType, { address: string, codeHash: string }>>;
 
   // A record of network addresses, where the key is the network identifier and the value is the address.
   networkAddresses: Record<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface SingletonDeploymentJSON {
   // 1.3.0: canonical, eip155, zksync
   // 1.4.1: canonical, zksync
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
-  deployments: AtLeastOne<Record<AddressType, { address: string, codeHash: string }>>;
+  deployments: AtLeastOne<Record<AddressType, { address: string; codeHash: string }>>;
 
   // A record of network addresses, where the key is the network identifier and the value is either a single address type or an array of address types.
   networkAddresses: Record<string, AddressType | AddressType[]>;
@@ -63,7 +63,7 @@ export interface SingletonDeployment {
   // 1.3.0: canonical, eip155, zksync
   // 1.4.1: canonical, zksync
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
-  deployments: AtLeastOne<Record<AddressType, { address: string, codeHash: string }>>;
+  deployments: AtLeastOne<Record<AddressType, { address: string; codeHash: string }>>;
 
   // A record of network addresses, where the key is the network identifier and the value is the address.
   networkAddresses: Record<string, string>;
@@ -77,7 +77,7 @@ export interface SingletonDeploymentV2 {
   released: boolean;
   contractName: string;
   version: string;
-  deployments: AtLeastOne<Record<AddressType, Record<'address' | 'codeHash', string>>>;
+  deployments: AtLeastOne<Record<AddressType, { address: string; codeHash: string }>>;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   abi: any[];
   networkAddresses: Record<string, string | string[]>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,4 @@
-export enum AddressType {
-  // The original address the contract was deployed on.
-  // Starting with 1.4.1, the contracts are deployed with an EIP155-compatible transaction.
-  CANONICAL = 'canonical',
-
-  // An address that was deployed with a transaction compatible with the EIP155 standard.
-  // The type is only used for 1.3.0 deployments.
-  EIP155 = 'eip155',
-
-  // An address that is deployed to the ZkSync VM networks.
-  ZKSYNC = 'zksync',
-}
+export type AddressType = 'canonical' | 'eip155' | 'zksync';
 
 export const enum DeploymentFormats {
   // The old format that only allows a single address for each network.
@@ -18,6 +7,8 @@ export const enum DeploymentFormats {
   // The new format that allows multiple addresses for each network.
   MULTIPLE = 'multiple',
 }
+
+type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
 
 export interface SingletonDeploymentJSON {
   // Indicates if the deployment is released.
@@ -38,7 +29,7 @@ export interface SingletonDeploymentJSON {
   // 1.3.0: canonical, eip155, zksync
   // 1.4.1: canonical, zksync
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
-  deployments: Record<string, Record<'address' | 'codeHash', string>>;
+  deployments: AtLeastOne<Record<AddressType, Record<'address' | 'codeHash', string>>>;
 
   // A record of network addresses, where the key is the network identifier and the value is either a single address type or an array of address types.
   networkAddresses: Record<string, AddressType | AddressType[]>;
@@ -65,8 +56,14 @@ export interface SingletonDeployment {
 
   // The address & hash of the contract code, where the key is the deployment type.
   // There could be multiple deployment types: canonical, eip155, zksync
+  // Possible addresses per version:
+  // 1.0.0: canonical
+  // 1.1.1: canonical
+  // 1.2.0: canonical
+  // 1.3.0: canonical, eip155, zksync
+  // 1.4.1: canonical, zksync
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
-  deployments: Record<string, Record<'address' | 'codeHash', string>>;
+  deployments: AtLeastOne<Record<AddressType, Record<'address' | 'codeHash', string>>>;
 
   // A record of network addresses, where the key is the network identifier and the value is the address.
   networkAddresses: Record<string, string>;
@@ -80,10 +77,10 @@ export interface SingletonDeploymentV2 {
   released: boolean;
   contractName: string;
   version: string;
-  deployments: Record<AddressType, Record<'address' | 'codeHash', string>>;
+  deployments: AtLeastOne<Record<AddressType, Record<'address' | 'codeHash', string>>>;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   abi: any[];
-  networkAddresses: Record<string, AddressType | AddressType[]>;
+  networkAddresses: Record<string, string | string[]>;
 }
 
 export interface DeploymentFilter {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface SingletonDeploymentJSON {
   // 1.3.0: canonical, eip155, zksync
   // 1.4.1: canonical, zksync
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
-  deployments: AtLeastOne<Record<AddressType, Record<'address' | 'codeHash', string>>>;
+  deployments: AtLeastOne<Record<AddressType, { address: string, codeHash: string }>>;
 
   // A record of network addresses, where the key is the network identifier and the value is either a single address type or an array of address types.
   networkAddresses: Record<string, AddressType | AddressType[]>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ enum AddressType {
   ZKSYNC = 'zksync',
 }
 
+export const enum DeploymentFormats {
+  // The old format that only allows a single address for each network.
+  SINGLETON = 'singleton',
+
+  // The new format that allows multiple addresses for each network.
+  MULTIPLE = 'multiple',
+}
+
 export interface SingletonDeploymentJSON {
   // Indicates if the deployment is released.
   released: boolean;
@@ -77,7 +85,7 @@ export interface SingletonDeploymentV2 {
   codeHash: string;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   abi: any[];
-  networkAddresses: Record<string, AddressType | AddressType[]>;
+  networkAddresses: Record<string, string | string[]>;
   addresses: Partial<Record<AddressType, string>>;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,13 +25,14 @@ const mapJsonToDeploymentsFormatV1 = (deployment: SingletonDeploymentJSON): Sing
   const defaultAddressType = Array.isArray(deployment.networkAddresses[DEFAULT_NETWORK_CHAIN_ID])
     ? deployment.networkAddresses[DEFAULT_NETWORK_CHAIN_ID][0]
     : deployment.networkAddresses[DEFAULT_NETWORK_CHAIN_ID];
-  const defaultAddress = deployment.deployments[defaultAddressType].address;
+  // The usage of non-null assertion below is safe, because we validate that the asset files are properly formed in tests
+  const defaultAddress = deployment.deployments[defaultAddressType]!.address;
   const networkAddresses = Object.fromEntries(
     Object.entries(deployment.networkAddresses).map(([chainId, addressTypes]) => [
       chainId,
       Array.isArray(addressTypes)
-        ? deployment.deployments[addressTypes[0]].address
-        : deployment.deployments[addressTypes].address,
+        ? deployment.deployments[addressTypes[0]]!.address
+        : deployment.deployments[addressTypes]!.address,
     ]),
   );
 
@@ -54,8 +55,9 @@ const mapJsonToDeploymentsFormatV2 = (deployment: SingletonDeploymentJSON): Sing
     Object.entries(deployment.networkAddresses).map(([chainId, addressTypes]) => [
       chainId,
       (Array.isArray(addressTypes)
-        ? (addressTypes.map((addressType) => deployment.deployments[addressType].address) as AddressType[])
-        : deployment.deployments[addressTypes].address) as AddressType,
+        ? // The usage of non-null assertion below is safe, because we validate that the asset files are properly formed in tests
+          (addressTypes.map((addressType) => deployment.deployments[addressType]!.address) as AddressType[])
+        : deployment.deployments[addressTypes]!.address) as AddressType,
     ]),
   );
 


### PR DESCRIPTION
This PR is a new API proposal for the functions that support the updated JSON format, which supports multiple deployments per network. Implements https://github.com/safe-global/safe-deployments/issues/685

The complexity of supporting multiple formats is handled by the utility function `findDeployments`, which contains a function overload with the deployment format parameter.

The new functions are added alongside the [existing API](https://github.com/safe-global/safe-deployments?tab=readme-ov-file#usage) functions but with plural `deployments` at the end of the function name.

**Example function:**
```
export const getProxyFactoryDeployments = (filter?: DeploymentFilter): SingletonDeploymentV2 | undefined => {
  return findDeployment(filter, factoryDeployments, DeploymentFormats.MULTIPLE);
};
```

**My reason for going with this approach**:
All the complexity is kept within the internal `findDeployment` function. Developers do not have to import and understand which format means what and don't have to import the additional `DeploymentFilter` enum. Type shenanigans are kept to a minimum. Also, the alternative approach below would require refactoring package functions to be defined via the `function` keyword because arrow functions do not support function overloads properly: https://www.perplexity.ai/search/typescript-arrow-function-over-tit1.0R8Rracx_PAUr1nVw#0

**Alternative approach:**
Add function overloads to the existing functions like this:
```
export const getSafeSingletonDeployment = (filter?: DeploymentFilter, format = DeploymentFormats.SINGLETON) => {
  return findDeployment(filter, _safeDeployments, format);
};
```