### PR TITLE
Refactor GitHub Review Script

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,23 +6,22 @@ on:
       - 'src/assets/**'
   workflow_dispatch:
 
-env:
-  GH_TOKEN: ${{ github.token }}
-  PR_NUMBER: ${{ github.event.number }}
-  REPO: ${{ github.repository }}
-
 permissions:
   pull-requests: write
 
 jobs:
-  review-check:
+  review:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: 'main'
-    - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@v1
-    - name: Check PR
+        ref: main
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Review PR
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        bash bin/github-review.sh ${PR_NUMBER}
+        npm ci
+        bash bin/github-review.sh ${{ github.event.number }}

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -26,10 +26,6 @@ if ! command -v gh &> /dev/null; then
     echo "ERROR: Please install the 'gh' GitHub CLI" 1>&2
     exit 1
 fi
-if ! command -v cast &> /dev/null; then
-    echo "ERROR: Please install the 'cast' tool included in the Foundry toolset" 1>&2
-    exit 1
-fi
 
 if [[ "$#" -ne 1 ]]; then
     echo "ERROR: Invalid number of arguments" 1>&2
@@ -38,44 +34,27 @@ if [[ "$#" -ne 1 ]]; then
 fi
 if ! [[ $1 =~ ^[0-9]+$ ]]; then
     echo "ERROR: $1 is not a valid GitHub PR number" 1>&2
-    usage
     exit 1
 fi
 pr=$1
-prChainID="$(gh pr view $pr | sed -nE 's/^- Chain_ID: ([0-9]+).*$/\1/p')"
-if [[ -z $prChainID ]]; then
+chainid="$(gh pr view $pr | sed -nE 's/^- Chain_ID: ([0-9]+).*$/\1/p')"
+if [[ -z $chainid ]]; then
     echo "ERROR: Chain ID not specified as per the PR Template" 1>&2
-    usage
     exit 1
 fi
-if ! [[ $prChainID =~ ^[0-9]+$ ]]; then
-    echo "ERROR: $prChainID is not a valid Chain ID number" 1>&2
-    usage
-    exit 1
-fi
-chainlistURL="https://chainlist.org/chain/$prChainID"
-if ! curl --fail -s -o /dev/null "$chainlistURL"; then
-    echo "ERROR: Chainlist URL $chainlistURL doesn't exist" 1>&2
-    usage
-    exit 1
-fi
-rpc="$(gh pr view $pr | sed -nE 's/^- RPC_URL: (https?:\/\/[^ ]+).*$/\1/p')"
+rpc="$(gh pr view $pr | sed -nE 's|^- RPC_URL: (https?://[^ ]+).*$|\1|p')"
 if [[ -z $rpc ]]; then
     echo "ERROR: RPC not specified as per the PR Template" 1>&2
-    usage
     exit 1
 fi
-chainid="$(cast chain-id --rpc-url "$rpc")"
-if [[ $chainid != $prChainID ]]; then
-    echo "ERROR: RPC $rpc doesn't match chain ID $prChainID" 1>&2
-    usage
+version="$(gh pr diff $pr --name-only | sed -nE 's|^src/assets/v([0-9\.]*)/.*$|\1|p' | sort -u)"
+if [[ "$(echo "$version" | wc -w)" -ne 1 ]]; then
+    echo "ERROR: Exactly one version must be added per PR ($version)" 1>&2
     exit 1
 fi
-version="$(gh pr diff $pr --name-only | sed -nE 's/^src\/assets\/v(1\.[3-4]\.[0-1]).*$/\1/p' | head -n 1)"
 versionFiles=(src/assets/v$version/*.json)
 if [[ ${#versionFiles[@]} -eq 0 ]]; then
     echo "ERROR: Version $version doesn't exist" 1>&2
-    usage
     exit 1
 fi
 
@@ -157,19 +136,7 @@ echo "Verifying Deployment Asset"
 gh pr diff $pr --patch | git apply --include 'src/assets/v'$version'/**' --verbose
 
 # Getting default addresses, address on the chain and checking code hash.
-deploymentTypes=($(jq -r --arg c "$chainid" '[.networkAddresses[$c]] | flatten | .[]' "$versionFiles"))
-for file in "${versionFiles[@]}"; do
-    for deploymentType in "${deploymentTypes[@]}"; do
-        defaultAddress=$(jq -r --arg t "$deploymentType" '.deployments[$t].address' "$file")
-        defaultCodeHash=$(jq -r --arg t "$deploymentType" '.deployments[$t].codeHash' "$file")
-        networkCodeHash=$(cast code "$defaultAddress" --rpc-url "$rpc" | tr -d '\n' | cast keccak)
-        if [[ $defaultCodeHash != $networkCodeHash ]]; then
-            echo "ERROR: "$file" ("$defaultAddress") code hash ("$defaultCodeHash") is not the same as the one created for the chain id ("$networkCodeHash")" 1>&2
-            exit 1
-        fi
-    done
-done
-
+npm run verify -s -- --version "v$version" --chainId "$chainid" --rpc "$rpc"
 echo "Network addresses & Code hashes are correct"
 
 git restore --ignore-unmerged -- src/assets

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -49,7 +49,7 @@ if [[ -z $rpc ]]; then
 fi
 version="$(gh pr diff $pr --name-only | sed -nE 's|^src/assets/v([0-9\.]*)/.*$|\1|p' | sort -u)"
 if [[ "$(echo "$version" | wc -w)" -ne 1 ]]; then
-    echo "ERROR: Exactly one version must be added per PR ($version)" 1>&2
+    echo "ERROR: Exactly one version must be added per PR" 1>&2
     exit 1
 fi
 versionFiles=(src/assets/v$version/*.json)
@@ -136,7 +136,7 @@ echo "Verifying Deployment Asset"
 gh pr diff $pr --patch | git apply --include 'src/assets/v'$version'/**' --verbose
 
 # Getting default addresses, address on the chain and checking code hash.
-npm run verify -s -- --version "v$version" --chainId "$chainid" --rpc "$rpc"
+npm run verify -s -- --version "v$version" --chainId "$chainid" --rpc "$rpc" --verbose
 echo "Network addresses & Code hashes are correct"
 
 git restore --ignore-unmerged -- src/assets

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,11 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "ethers": "^6.13.1",
         "jest": "^29.7.0",
         "prettier": "^3.3.2",
         "ts-jest": "^29.1.5",
+        "ts-node": "^10.9.2",
         "typescript": "^5.5.2",
         "typescript-eslint": "^7.14.1"
       }
@@ -33,6 +35,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -599,6 +607,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "dev": true,
@@ -1031,6 +1061,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.1",
       "dev": true,
@@ -1053,18 +1092,34 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1137,6 +1192,30 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -1486,6 +1565,24 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "dev": true,
@@ -1559,6 +1656,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1896,6 +1999,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -1957,6 +2066,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2299,6 +2417,46 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.1.tgz",
+      "integrity": "sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -4760,6 +4918,49 @@
         }
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "dev": true,
@@ -4845,6 +5046,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "dev": true,
@@ -4913,6 +5120,27 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "dev": true,
@@ -4944,6 +5172,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -8,18 +8,17 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
-    "src",
-    "test",
-    "build"
+    "src"
   ],
   "scripts": {
     "build": "rimraf dist && tsc",
     "lint": "npm run lint:ts && npm run lint:json",
-    "lint:ts": "eslint --max-warnings 0 src/",
+    "lint:ts": "eslint --max-warnings 0 src/ scripts/",
     "lint:json": "prettier -c src/assets/*/*.json",
     "lint:fix": "npm run lint:fix:ts && npm run lint:fix:json",
     "lint:fix:ts": "npm run lint:ts -- --fix",
     "lint:fix:json": "prettier -w src/assets/*/*.json",
+    "verify": "ts-node scripts/verify.ts",
     "prepack": "npm run build",
     "test": "jest"
   },
@@ -44,9 +43,11 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "ethers": "^6.13.1",
     "jest": "^29.7.0",
     "prettier": "^3.3.2",
     "ts-jest": "^29.1.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.2",
     "typescript-eslint": "^7.14.1"
   },

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -40,7 +40,7 @@ async function main() {
     if (options.verbose) {
       console.debug(...msg);
     }
-  }
+  };
 
   await fetch(`https://chainlist.org/chain/${options.chainId}`).then((response) => {
     if (!response.ok) {

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -62,12 +62,12 @@ async function main() {
     const json: SingletonDeploymentJSON = JSON.parse(await fs.readFile(asset, 'utf-8'));
     debug(`${json.contractName} deployments:`);
 
-    const deployments = json.networkAddresses[options.chainId];
-    if (deployments === undefined) {
+    const networkAddresses = json.networkAddresses[options.chainId];
+    if (networkAddresses === undefined) {
       throw new Error(`missing ${json.contractName} deployment`);
     }
 
-    for (const deployment of [deployments].flat()) {
+    for (const deployment of [networkAddresses].flat()) {
       if (json.deployments[deployment] === undefined) {
         throw new Error(`invalid ${json.contractName} deployment "${deployment}"`);
       }

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+
+import { ethers } from 'ethers';
+
+import type { SingletonDeploymentJSON } from '../src/types';
+
+type Options = {
+  version: string;
+  chainId: string;
+  rpc: string;
+};
+
+function parseOptions(): Options {
+  const options = {
+    version: { type: 'string' },
+    chainId: { type: 'string' },
+    rpc: { type: 'string' },
+  } as const;
+  const { values } = util.parseArgs({ options });
+
+  for (const option of Object.keys(options) as Array<keyof typeof options>) {
+    if (values[option] === undefined) {
+      throw new Error(`missing --${option} flag`);
+    }
+  }
+
+  return values as Options;
+}
+
+async function main() {
+  const options = parseOptions();
+
+  await fetch(`https://chainlist.org/chain/${options.chainId}`).then((response) => {
+    if (!response.ok) {
+      throw new Error(`chain is not registered on Chainlist`);
+    }
+  });
+
+  const provider = new ethers.JsonRpcProvider(options.rpc);
+  const { chainId } = await provider.getNetwork();
+  if (`${chainId}` !== options.chainId) {
+    throw new Error(`RPC chain ID ${chainId} does not match expected ${options.chainId}`);
+  }
+
+  const assets = path.join('src', 'assets', options.version);
+  for (const file of await fs.readdir(assets)) {
+    const asset = path.join(assets, file);
+    const json: SingletonDeploymentJSON = JSON.parse(await fs.readFile(asset, 'utf-8'));
+
+    const deployments = json.networkAddresses[options.chainId];
+    if (deployments === undefined) {
+      throw new Error(`missing ${json.contractName} deployment`);
+    }
+
+    for (const deployment of [deployments].flat()) {
+      if (json.deployments[deployment] === undefined) {
+        throw new Error(`invalid ${json.contractName} deployment "${deployment}"`);
+      }
+
+      const { address, codeHash: expectedCodeHash } = json.deployments[deployment];
+      const code = await provider.getCode(address);
+      if (ethers.dataLength(code) === 0) {
+        throw new Error(`${json.contractName} not deployed at ${address}`);
+      }
+      const codeHash = ethers.keccak256(code);
+      if (codeHash !== expectedCodeHash) {
+        throw new Error(`${json.contractName} code hash ${codeHash} does not match expected ${expectedCodeHash}`);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`ERROR: ${err.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
This PR splits the GitHub review script into two pieces:
1. The old review script, that takes a PR and verifies it meets all the requirements for deployment PRs
2. A new Node.JS script that verifies the actual deployment and code, but does not check all the PR rules.

The reason for this split is to accomodate PRs like #695, where the RPC url is not included in PR description, and more than one version is added at a time. It essentially adds a "manual" network verification scheme that can be used in special cases the PR above.

Additionally, it removes the requiment on `cast`. This is particularly important for automated checks, as we do not want to depend on nightly tools that don't have releases with somewhat guaranteed behaviour.

Lastly, this PR does a couple minor fixes to the review script, in particular it causes it to fail if more than one version is changed in the PR, and doesn't print usage information on general errors.