### PR TITLE
Run on PR Branch

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: main
     - uses: actions/setup-node@v4
       with:
         node-version: 20
@@ -23,5 +21,10 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        git fetch origin main
+        if ! git diff --exit-code main -- bin/github-review.sh; then
+          echo "ERROR: GitHub review script is not up-to-date" 1>&2
+          exit 1
+        fi
         npm ci
         bash bin/github-review.sh ${{ github.event.number }}

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -132,10 +132,13 @@ if [[ $isHighestChainID == 1 ]]; then
     done
 fi
 
-echo "Verifying Deployment Asset"
-gh pr diff $pr --patch | git apply --include 'src/assets/v'$version'/**' --verbose
+# Assume that if `GITHUB_HEAD_REF` is set, then we are running in CI and have already checked out
+# the deployment files, otherwise apply the patch on top of the current branch.
+if [[ -z "$GITHUB_HEAD_REF" ]]; then
+    gh pr diff $pr --patch | git apply --include 'src/assets/v'$version'/**' --verbose
+fi
 
-# Getting default addresses, address on the chain and checking code hash.
+echo "Verifying Deployment Asset"
 npm run verify -s -- --version "v$version" --chainId "$chainid" --rpc "$rpc" --verbose
 echo "Network addresses & Code hashes are correct"
 


### PR DESCRIPTION
This PR changes the review script to run on the PR branch in CI instead of trying to apply changes to the branch. This is done to avoid issues where merges to `main` cause PRs to no longer review properly.

In the past, we made these changes in order to ensure that the script gets run as-expected from `main` to make sure that PRs couldn't change the scripts and cause them to pass, but this is now ensured by the GitHub action itself.
