### PR TITLE
[DRAFT]: Test GitHub Release Publishing in Workflows

### DIFF
--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -1,0 +1,26 @@
+# DO NOT MERGE
+#
+# This workflow file is created to help debug GH issue around publishing draft
+# PRs which are failing for whatever reason.
+
+name: GH
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  gh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - env:
+          GH_DEBUG: 1
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit v1.37.2 --draft=false


### PR DESCRIPTION
# :warning: **DO NOT MERGE** :warning:

Currently, release publishing is failing in GitHub workflows with the following error:

```
publishing draft release
HTTP 422: Validation Failed (https://api.github.com/repos/safe-global/safe-deployments/releases/165840580)
pre_receive Repository rule violations found
Cannot create ref due to create name restrictions.
Published releases must have a valid tag
```

In order to more quickly debug the issue and try to find solutions to the problem, I created this Draft PR that will run workflows that try to publish the draft release.