### PR TITLE
feat: add Cheese Chain Mainnet is a Layer 3 EVM chain by Palmera

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -237,6 +237,7 @@
     "200810": "canonical",
     "328527": "canonical",
     "333999": "canonical",
+    "383353": "canonical",
     "421611": "canonical",
     "421613": "canonical",
     "421614": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Cheese Chain Mainnet, Native Token $Cheese

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 383353

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
- RPC_URL: https://rpc.cheesechain.lol/http

Relevant information:

Block: explorer: https://fetascan.io/
API BlockExplorer: https://fetascan.io/api-docs

