### PR TITLE
feat: add arbitrum for 1.1.1

### DIFF
--- a/src/assets/v1.1.1/gnosis_safe.json
+++ b/src/assets/v1.1.1/gnosis_safe.json
@@ -16,6 +16,7 @@
     "88": "canonical",
     "100": "canonical",
     "246": "canonical",
+    "42161": "canonical",
     "73799": "canonical"
   },
   "abi": [

--- a/src/assets/v1.1.1/proxy_factory.json
+++ b/src/assets/v1.1.1/proxy_factory.json
@@ -16,6 +16,7 @@
     "88": "canonical",
     "100": "canonical",
     "246": "canonical",
+    "42161": "canonical",
     "73799": "canonical"
   },
   "abi": [


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 42161

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
- RPC_URL: wss://arbitrum-one.publicnode.com

Relevant information:
We want to add existing contracts (in this case Optimism) to the 1.1.1 deployments for the multichain feature. To be able to see if it is possible to replay a safe creation, the contract used to deploy the original safe must be in safe-deployments.

https://www.notion.so/safe-global/76f265123c0a4ad680947ce489804342?v=f9f164524ec4464286fdc38f31589d0