### PR TITLE
Split workflows

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,24 @@
+name: Bump Version
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: |
+          npm ci
+          bash bin/github-release.sh --verbose bump
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Draft Release
 on:
   workflow_dispatch:
 
@@ -19,6 +19,6 @@ jobs:
           node-version: 20
       - run: |
           npm ci
-          bash bin/github-release.sh --verbose
+          bash bin/github-release.sh --verbose draft
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,24 @@
+name: Publish Release
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: |
+          npm ci
+          bash bin/github-release.sh --verbose publish
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -12,7 +12,7 @@ It provides functionality for automatically:
  • Publishing GitHub releases once the version lands on NPM
 
 USAGE
-    bash bin/github-release.sh [-v|--verbose] [-n|--dry-run]
+    bash bin/github-release.sh [-v|--verbose] [-n|--dry-run] [bump|draft|publish]
 
 OPTIONS
     -v | --verbose      Verbose output
@@ -20,12 +20,16 @@ OPTIONS
                         release GitHub.
 
 EXAMPLES
-    bash bin/github-release.sh
+    bash bin/github-release.sh bump
+    bash bin/github-release.sh draft
+    bash bin/github-release.sh publish
 EOF
 }
 
 verbose="n"
 dryrun="n"
+command=""
+
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-v|--verbose)
@@ -34,6 +38,9 @@ while [[ $# -gt 0 ]]; do
 	-n|--dry-run)
 		dryrun="y"
 		;;
+	bump|draft|publish)
+		command="$1"
+		;;
 	*)
 		usage
 		exit 1
@@ -41,6 +48,11 @@ while [[ $# -gt 0 ]]; do
 	esac
 	shift
 done
+
+if [[ -z "$command" ]]; then
+    usage
+    exit 1
+fi
 
 log() {
 	if [[ "$verbose" == "y" ]]; then
@@ -78,65 +90,75 @@ draft="$(gh release view "$tag" --json isDraft,targetCommitish --jq 'if(.isDraft
 log "commit:  ${commit}"
 log "draft:   ${draft:-none}"
 
-if [[ -z "$draft" ]] && [[ "$current" == "$latest" ]]; then
-	# In this case, we have no existing draft, and the current version is
-	# the same as the latest release, so we need to create a new PR to bump
-	# the package version.
-	log "==> Bumping Version"
+case $command in
+	"bump")
+		if [[ -z "$draft" ]] && [[ "$current" == "$latest" ]]; then
+			# In this case, we have no existing draft, and the current version is
+			# the same as the latest release, so we need to create a new PR to bump
+			# the package version.
+			log "==> Bumping Version"
 
-	git fetch --tags --force --quiet
-	if [[ -n "$(git tag -l --points-at HEAD | awk '$1 == "'$tag'"')" ]]; then
-		log "no changes since latest release"
-		exit 0
-	fi
+			git fetch --tags --force --quiet
+			if [[ -n "$(git tag -l --points-at HEAD | awk '$1 == "'$tag'"')" ]]; then
+				log "no changes since latest release"
+				exit 0
+			fi
 
-	newtag="$(npm version patch --no-git-tag-version)"
-	log "bumping to $newtag"
+			newtag="$(npm version patch --no-git-tag-version)"
+			log "bumping to $newtag"
 
-	branch="bump/$newtag"
-	if git ls-remote --heads origin | grep "refs/heads/$branch\$" >/dev/null; then
-		log "version bump PR already exists"
-		exit 0
-	fi
-	if [[ "$dryrun" == "n" ]]; then
-		log "creating PR bumping version"
-		git checkout -b "$branch"
-		git commit -am "Bump Version to $newtag"
-		git push -u origin "$branch"
-		gh pr create --fill
-	fi
-elif [[ "$current" != "$latest" ]]; then
-	# In this case, the current version is newer that the latest released
-	# version on NPM, so we create or update the draft release to ensure it
-	# includes the latest version.
-	log "==> Drafting Release"
-
-	if [[ "$commit" == "$draft" ]]; then
-		log "draft is already at latest commit"
-		exit 0
-	fi
-
-	log "generating NPM package"
-	npm pack
-	package="${name#@}-$current.tgz"
-	package="${package//\//-}"
-
-	if [[ "$dryrun" == "n" ]]; then
-		log "drafting release with NPM tarball"
-		if [[ -n "$draft" ]]; then
-			log "cleaning up existing draft"
-			gh release delete "$tag" --yes
+			branch="bump/$newtag"
+			if git ls-remote --heads origin | grep "refs/heads/$branch\$" >/dev/null; then
+				log "version bump PR already exists"
+				exit 0
+			fi
+			if [[ "$dryrun" == "n" ]]; then
+				log "creating PR bumping version"
+				git checkout -b "$branch"
+				git commit -am "Bump Version to $newtag"
+				git push -u origin "$branch"
+				gh pr create --fill
+			fi
 		fi
-		gh release create "$tag" --draft --generate-notes --target "$commit" --title "$tag" "$package"
-	fi
-else # if [[ -n "$draft" ]] && [[ "$current" == "$latest" ]]; then
-	# In this case, there is an existing draft, and the latest version is
-	# equal to it. Publish the draft release!
-	log "==> Publishing Release"
+		;;
+	"draft")
+		if [[ -z "$draft" ]] && [[ "$current" != "$latest" ]]; then
+			# In this case, the current version is newer that the latest released
+			# version on NPM, so we create or update the draft release to ensure it
+			# includes the latest version.
+			log "==> Drafting Release"
 
-	tag="v$current"
-	if [[ "$dryrun" == "n" ]]; then
-		log "publishing draft release"
-		gh release edit "$tag" --draft=false
-	fi
-fi
+			if [[ "$commit" == "$draft" ]]; then
+				log "draft is already at latest commit"
+				exit 0
+			fi
+
+			log "generating NPM package"
+			npm pack
+			package="${name#@}-$current.tgz"
+			package="${package//\//-}"
+
+			if [[ "$dryrun" == "n" ]]; then
+				log "drafting release with NPM tarball"
+				if [[ -n "$draft" ]]; then
+					log "cleaning up existing draft"
+					gh release delete "$tag" --yes
+				fi
+				gh release create "$tag" --draft --generate-notes --target "$commit" --title "$tag" "$package"
+			fi
+		fi
+		;;
+	"publish")
+		if [[ -n "$draft" ]] && [[ "$current" == "$latest" ]]; then
+			# In this case, there is an existing draft, and the latest version is
+			# equal to it. Publish the draft release!
+			log "==> Publishing Release"
+
+			tag="v$current"
+			if [[ "$dryrun" == "n" ]]; then
+				log "publishing draft release"
+				gh release edit "$tag" --draft=false
+			fi
+		fi
+		;;
+esac

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -119,6 +119,8 @@ case $command in
 				git push -u origin "$branch"
 				gh pr create --fill
 			fi
+		else
+			log "skipped version bump. Either a draft release already exists or the current version is not the latest."
 		fi
 		;;
 	"draft")
@@ -140,12 +142,10 @@ case $command in
 
 			if [[ "$dryrun" == "n" ]]; then
 				log "drafting release with NPM tarball"
-				if [[ -n "$draft" ]]; then
-					log "cleaning up existing draft"
-					gh release delete "$tag" --yes
-				fi
 				gh release create "$tag" --draft --generate-notes --target "$commit" --title "$tag" "$package"
 			fi
+		else
+			log "draft release not created. Either a draft release already exists or the current version equals the latest NPM release."
 		fi
 		;;
 	"publish")
@@ -159,6 +159,8 @@ case $command in
 				log "publishing draft release"
 				gh release edit "$tag" --draft=false
 			fi
+		else 
+			log "skipped release publishing. Either no draft release exists or the current version is not the latest NPM release."
 		fi
 		;;
 esac


### PR DESCRIPTION
The current github `release` workflow has 3 use cases:
1. Create PR to bump version
2. Create draft release
3. Publish draft release to Github if already published to NPM

Using this workflow is not intuitive and can lead to confusion as multiple actions (bumping the version, creating a draft release, and publishing the release) are combined into a single workflow.

Changes in PR:
- Split github `release` workflow into following:
  - Bump version workflow
  - Create draft release workflow
  - Publish release to github workflow

This separation increases the clarity, maintainability, and flexibility of the release process.