### PR TITLE
Add Q Mainnet network (v1.3.0)

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -198,6 +198,7 @@
     "28979": "canonical",
     "33401": "canonical",
     "34443": ["canonical", "eip155"],
+    "35441": "canonical",
     "41455": ["canonical", "eip155"],
     "42161": "canonical",
     "42170": "canonical",


### PR DESCRIPTION
## Add Q Mainnet 

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 35441

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
- RPC_URL: https://rpc.q.org/

Relevant information:

Explorer URL: https://explorer.q.org/
