### PR TITLE
Add contracts v1.4.1 to Japan Open Chain Mainnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "10": "canonical",
     "56": "canonical",
+    "81": "canonical",
     "100": "canonical",
     "137": "canonical",
     "196": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "10": "canonical",
     "56": "canonical",
+    "81": "canonical",
     "100": "canonical",
     "137": "canonical",
     "196": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "10": "canonical",
     "56": "canonical",
+    "81": "canonical",
     "100": "canonical",
     "137": "canonical",
     "196": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -21,6 +21,7 @@
     "41": "canonical",
     "56": "canonical",
     "71": "canonical",
+    "81": "canonical",
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 81

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
- RPC_URL: https://rpc-1.japanopenchain.org:8545

Relevant information:
Add any other relevant information like blockexplorer, any annotation...
- Fixed #822 
- Blockexplorer: https://explorer.japanopenchain.org
- Merged PRs for v1.3.0: https://github.com/safe-global/safe-deployments/pull/310
