### PR TITLE
Add contracts v1.4.1 to Japan Open Chain Testnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -21,6 +21,7 @@
     "1337": "canonical",
     "5000": "canonical",
     "8453": "canonical",
+    "10081": "canonical",
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -21,6 +21,7 @@
     "1337": "canonical",
     "5000": "canonical",
     "8453": "canonical",
+    "10081": "canonical",
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -21,6 +21,7 @@
     "1337": "canonical",
     "5000": "canonical",
     "8453": "canonical",
+    "10081": "canonical",
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -85,6 +85,7 @@
     "8194": "canonical",
     "8453": "canonical",
     "9001": "canonical",
+    "10081": "canonical",
     "10242": "canonical",
     "10243": "canonical",
     "11235": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 10081

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
- RPC_URL: https://rpc-1.testnet.japanopenchain.org:8545

Relevant information:
Add any other relevant information like blockexplorer, any annotation...
Fixed #821 
Blockexplorer: https://explorer.testnet.japanopenchain.org/
Merged PRs for v1.3.0: https://github.com/safe-global/safe-deployments/pull/308