### PR TITLE
Delay between checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Please fill the following form:
 Provide the Chain ID (Only 1 chain id per PR).
 - Chain_ID: 
 
-Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
+Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
 - RPC_URL: 
 
 Relevant information:

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
-import { setTimeout } from 'node:timers/promises';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 import { ethers } from 'ethers';
 
@@ -85,7 +85,7 @@ async function main() {
 
       debug(`• ${deployment} deployment OK`);
     }
-    await setTimeout(1000);
+    await sleep(1000);
   }
 }
 

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -84,6 +84,7 @@ async function main() {
 
       debug(`• ${deployment} deployment OK`);
     }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 }
 

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
+import { setTimeout } from 'node:timers/promises';
 
 import { ethers } from 'ethers';
 
@@ -84,7 +85,7 @@ async function main() {
 
       debug(`• ${deployment} deployment OK`);
     }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
   }
 }
 


### PR DESCRIPTION
Sometimes when multiple deployments exist for a single chain, RPC with lower limits (free tier or lower capacity) results in a timeout.

To avoid this issue, we are adding a delay of 1 sec (which can be increased later, if found that this delay is not enough) between each file is checked.