### PR TITLE
feat: add 1.3.0 zksync contracts for new Cronos zkEVM Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -67,6 +67,7 @@
     "195": "eip155",
     "196": ["eip155", "canonical"],
     "204": ["eip155", "canonical"],
+    "240": "zksync",
     "246": "canonical",
     "250": ["canonical", "eip155"],
     "252": ["eip155", "canonical"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID.
- Chain_ID: 240

Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
- RPC_URL: https://testnet.zkevm.cronos.org

Relevant information:
- https://github.com/safe-global/safe-singleton-factory/issues/751
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-240.json

```
deploying "SimulateTxAccessor" (tx: 0x0aa5b156b0255703f558e2c04b15f073d8428990d62ad3ddd57c2d9497724a21)...: deployed at 0x4191E2e12E8BC5002424CE0c51f9947b02675a44 with 476635 gas
deploying "GnosisSafeProxyFactory" (tx: 0xbf90209ccc2ec9a40c9436d2b8967b9e9196a36ca19c3a7e2ba63279949b03ec)...: deployed at 0xDAec33641865E4651fB43181C6DB6f7232Ee91c2 with 1229056 gas
deploying "DefaultCallbackHandler" (tx: 0x48afcba5e7a49162390356f088a10ba25dc75490cbdbf6d9be0781367b2cbfa7)...: deployed at 0x08798512808f838a06BCe7c26905f05e94dF6f50 with 369610 gas
deploying "CompatibilityFallbackHandler" (tx: 0xf20e6604f9152af0451f80bb2597977bcc50bd8ca3f8fe6202d90ee40cb994a7)...: deployed at 0x2f870a80647BbC554F3a0EBD093f11B4d2a7492A with 1419914 gas
deploying "CreateCall" (tx: 0xfc81153ec330addecade2cd37c1025af77ed3e18c3c92098d4ab2e780b43a79c)...: deployed at 0xcB8e5E438c5c2b45FbE17B02Ca9aF91509a8ad56 with 406654 gas
deploying "MultiSend" (tx: 0x6ac45a4ca838e5c1fe806b65c5ae2e869b43f63232a8cccd5d89a68074613f05)...: deployed at 0x0dFcccB95225ffB03c6FBB2559B530C2B7C8A912 with 382658 gas
deploying "MultiSendCallOnly" (tx: 0x223225b88a41a4175ea8f779d3c974d5136df186171960ab53095a893299b0e3)...: deployed at 0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F with 287360 gas
deploying "SignMessageLib" (tx: 0xd8000b6da765aa1692c1181ce9c1fbaaab14e4755b6a86d37491f6abb6d6bc84)...: deployed at 0x357147caf9C0cCa67DfA0CF5369318d8193c8407 with 564686 gas
deploying "GnosisSafeL2" (tx: 0xe429b87ff0223fac9a4068600ed2cfc7daa9ae2c6e83526cb8c1eebfee9d6502)...: deployed at 0x1727c2c531cf966f902E5927b98490fDFb3b2b70 with 4133116 gas
deploying "GnosisSafe" (tx: 0x11e9002c8489985d8a41eab6898bb115c20815708ff010d495ce54f73259e4c6)...: deployed at 0xB00ce5CCcdEf57e539ddcEd01DF43a13855d9910 with 3942411 gas
```

