### PR TITLE
feat: add manta sepolia 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -31,6 +31,7 @@
     "81457": "canonical",
     "84532": "canonical",
     "534352": "canonical",
+    "3441006": "canonical",
     "11155111": "canonical",
     "1313161554": "canonical"
   },

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -31,6 +31,7 @@
     "81457": "canonical",
     "84532": "canonical",
     "534352": "canonical",
+    "3441006": "canonical",
     "11155111": "canonical",
     "1313161554": "canonical"
   },

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -31,6 +31,7 @@
     "81457": "canonical",
     "84532": "canonical",
     "534352": "canonical",
+    "3441006": "canonical",
     "11155111": "canonical",
     "1313161554": "canonical"
   },

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -130,6 +130,7 @@
     "534352": "canonical",
     "555666": "canonical",
     "713715": "canonical",
+    "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 3441006

Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
- RPC_URL: https://pacific-rpc.sepolia-testnet.manta.network/http

Relevant information:
blockexplorer: https://pacific-explorer.sepolia-testnet.manta.network/
deploying "SimulateTxAccessor" (tx: 0x438d5cddff87fc7871158b555312f236652fbc41f4b79f290691e70b97a67236)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0xf5c8c02e7faa60dc8eafda4a9f836dc5fa7c31178c10350eb813935b709937b4)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0xd8273fb541f7276736dc1ed910f9f263fe7886906273e2669c43ed321fc0188a)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xaca1e2613287bb8790328af5af8f3093b3903b8051c74a2643a285864afba584)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0xac25c809a11972f020b63356eee5921ea5be400f60d28e5506b97a3ec4cc64ef)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0xa2e5a859c0fc35a3ef09e7c913e8fdce85a264434a05bf301928649d77ac0f36)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0xa9687545c8257b2654a7ded1ec6c80ecee0994bf7285eb1310567f77319b5e60)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x5446416df8e9c51c7a3625126b8171cbee9d4a0ed4b84f8e81fb52baae162325)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0xf228274efeb86bb2c48cea080c25c6400fe855d8c4d9d25627400062d3005b18)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0xc8862aaa43192989876cae242391c9ae93052dec08a0d6316d81d1445c6c2588)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x4d6ba64fca82879a6d92bfeded67c635840bc61f915352b1adea54cd57f902fb)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x95187328679952d73eb8ddc2f8eff8e307d2c3e42e005615f1d5b34c89708950)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0xd0d2bbc653c7add7d5d4a80e3229cdff69c5129d3b29a5b3ecc138ed1250f3c7)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
