### PR TITLE
feat: add celo alfajores 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -27,6 +27,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "59144": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -27,6 +27,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "59144": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -27,6 +27,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "59144": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -108,6 +108,7 @@
     "42161": "canonical",
     "42220": "canonical",
     "43114": "canonical",
+    "44787": "canonical",
     "54211": "canonical",
     "59140": "canonical",
     "59141": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 44787

Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
- RPC_URL: https://alfajores-forno.celo-testnet.org

Relevant information:
blockexplorer: https://celo-alfajores.blockscout.com/
deploying "SimulateTxAccessor" (tx: 0xb35f90a56a231177a8c7148d27acf6aa642c905b16de1d098d8b6b4808076b41)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
deploying "TokenCallbackHandler" (tx: 0xb2183018c311dd8ca5f7404601484e9b2230c6a9538fdff6a2d9df5c74879017)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
deploying "CreateCall" (tx: 0xc5b83480adbeed502496323d806005b2e01a405b73fbf823b6457985c51cf0af)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
deploying "MultiSendCallOnly" (tx: 0x9c3f216c1086b1d2bbdacfb2d2a3c81dee5d2cdea78f9f9882d55aec973eafa6)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x0816c25659bc0c319d8cfd637b6aace3a6aa4b00a04b9ea00358b8207c791eef)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x0d41b73dc8993307c77f920fd2ff96b6a2c0e8784deb0d4703bba0efcc940afe)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x5d2d49f50b441a92692cad3a747aa793c3aa89c0057e471a98f9c3c118877fec)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
deploying "SafeToL2Migration" (tx: 0x53c244f636d15e66ef647b113181490c7170f334c6b3ff7c57cca2a3d67bea00)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0xe894ec15cce9541d8c9d088d4fbe7d6b44a7c79942f93a8cd45c14ec101c9a68)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
