### PR TITLE
feat: add polygon cardona 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -23,6 +23,7 @@
     "1101": "canonical",
     "1337": "canonical",
     "2187": "canonical",
+    "2442": "canonical",
     "5000": "canonical",
     "5115": "canonical",
     "8453": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -23,6 +23,7 @@
     "1101": "canonical",
     "1337": "canonical",
     "2187": "canonical",
+    "2442": "canonical",
     "5000": "canonical",
     "5115": "canonical",
     "8453": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -23,6 +23,7 @@
     "1101": "canonical",
     "1337": "canonical",
     "2187": "canonical",
+    "2442": "canonical",
     "5000": "canonical",
     "5115": "canonical",
     "8453": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -63,6 +63,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2442": "canonical",
     "2810": "canonical",
     "3338": "canonical",
     "3636": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2442

Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
- RPC_URL: https://polygon-zkevm-cardona.blockpi.network/v1/rpc/public

Relevant information:
blockexplorer: https://cardona-zkevm.polygonscan.com/
deploying "SimulateTxAccessor" (tx: 0x33f8c214ea74f02df94483fc46936a96b140d87566e7de9438a190ed8b206c0e)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
deploying "SafeProxyFactory" (tx: 0xf71b0e7e29cec5e0b9fb1c290634e77de731d18e141dcdc05b3cb210dc347413)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712428 gas
deploying "TokenCallbackHandler" (tx: 0xa5dc75263f630db14f0a2b1bb6a2424cb923e4d3088c528ecb8edea9467b1e8d)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
deploying "CompatibilityFallbackHandler" (tx: 0x82a3246dad0359078688e4dbb1b7fdfa1bf1ce8748a4ff0314e3026c)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1269776 gas
deploying "CreateCall" (tx: 0x0f7ddd6f4d7b9a5b94a97dfed3a920f474b8dba57e82284d73c04c4a1373b889)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
deploying "MultiSend" (tx: 0x512711706ba8f9cfecbc741d8afe5cef5e31638a67923e8ff938ba53d975975d)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190016 gas
deploying "MultiSendCallOnly" (tx: 0x9713505de6460995659266fc8d0f4e1a7f3459111111d78883d695b2ed218496)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0xacffdfeb26e6fc25e37aa7cd8f15d183183207a70549af59e605b71168a97f37)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0xa7ac45b51b816ceefc4d4fbf247fc5a60568ee676bc3f34ce6ef95b59ec7c28a)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0x6435198a378459622e35b3715aea88d9be3d2e77df1a68a68eee706213088b82)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
deploying "SafeL2" (tx: 0x0f7698a328d9cf4e305604b5e501c6fba83d58ed5ef0933a3d7e856cf497c0dc)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5331001 gas
deploying "SafeToL2Migration" (tx: 0xa17a0b6a4f3c83481ba279b48f4614d63ebcc421d361941e6e2854d42d8e57eb)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0x5c4483cc5195761cdb1eb3fe61251d07106e782e535ba749ba5f9b1279a38602)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas
