### PR TITLE
feat: add 1.3.0 contracts for Ink Sepolia

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -267,6 +267,7 @@
     "656476": ["eip155", "canonical"],
     "660279": "canonical",
     "713715": ["eip155", "canonical"],
+    "763373": "eip155",
     "764984": "canonical",
     "808813": "eip155",
     "810180": "zksync",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 763373

Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
- RPC_URL: https://rpc-gel-sepolia.inkonchain.com

Relevant information:
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-763373.json
