### PR TITLE
Deployment Automation

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,5 +1,8 @@
 name: Bump Version
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,5 +1,7 @@
 name: Draft Release
 on:
+  schedule:
+    - cron: '0 10 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,7 +1,7 @@
 name: Draft Release
 on:
   schedule:
-    - cron: '0 10 * * 1'
+    - cron: '0 10 * * 1' # Every Monday at 10:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request includes updates to the GitHub workflows to automate version bumping and release drafting. The most important changes include adding a push trigger for the version bump workflow and scheduling the draft release workflow to run weekly.

Updates to GitHub workflows:

* [`.github/workflows/bump_version.yml`](diffhunk://#diff-53150b4763f4a2e08b0d85622cd0640ba3b10eb7a9bca1cfec2b7fb5111b00feR3-R5): Added a push trigger for the `main` branch to automate version bumping.
* [`.github/workflows/draft_release.yml`](diffhunk://#diff-cf9ff1c5bc30168737462f98fc8932addf46407f697d9914bd8e57ffb61da05eR3-R4): Scheduled the draft release workflow to run every Monday at 10 AM (UTC, Open Question, should we make it to run on a different time? Or more regularly?).