### PR TITLE
RPC Taken from `ethereum-lists` directly

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,11 @@
 ## Add new chain
 
-> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. This entire paragraph should be deleted.
+> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.
 
 Please fill the following form:
 
 Provide the Chain ID (Only 1 chain id per PR).
 - Chain_ID: 
-
-Provide RPC URL for the chain (should be able to query atleast 3+ requests per second for automatic PR check).
-- RPC_URL: 
 
 Relevant information:
 Add any other relevant information like blockexplorer, any annotation...

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -45,7 +45,7 @@ if [[ -z $chainid ]]; then
     echo "ERROR: Chain ID not specified as per the PR Template" 1>&2
     exit 1
 fi
-rpc="$(gh pr view $pr | sed -nE 's|^- RPC_URL: (https?://[^ ]+).*$|\1|p')"
+rpc="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ethereum-lists/chains/contents/_data/chains/eip155-$chainid.json | jq -r .content | base64 --decode | jq -r '.rpc[0]')"
 if [[ -z $rpc ]]; then
     echo "ERROR: RPC not specified as per the PR Template" 1>&2
     exit 1

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -47,7 +47,7 @@ if [[ -z $chainid ]]; then
 fi
 rpc="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ethereum-lists/chains/contents/_data/chains/eip155-$chainid.json | jq -r .content | base64 --decode | jq -r '.rpc[0]')"
 if [[ -z $rpc ]]; then
-    echo "ERROR: RPC not specified as per the PR Template" 1>&2
+    echo "ERROR: RPC not fetched correctly from the ethereum-lists" 1>&2
     exit 1
 fi
 version="$(gh pr diff $pr --name-only | sed -nE 's|^src/assets/v([0-9\.]*)/.*$|\1|p' | sort -u)"

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -45,7 +45,8 @@ if [[ -z $chainid ]]; then
     echo "ERROR: Chain ID not specified as per the PR Template" 1>&2
     exit 1
 fi
-rpc="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ethereum-lists/chains/contents/_data/chains/eip155-$chainid.json | jq -r .content | base64 --decode | jq -r '.rpc[0]')"
+chainInfo="https://raw.githubusercontent.com/ethereum-lists/chains/refs/heads/master/_data/chains/eip155-$chainid.json"  
+rpc="$(curl -sfL "$chainInfo" | jq -r '.rpc[0]')" 
 if [[ -z $rpc ]]; then
     echo "ERROR: RPC not fetched correctly from the ethereum-lists" 1>&2
     exit 1


### PR DESCRIPTION
Solved #688 

This pull request includes a small but significant change to the `.github/PULL_REQUEST_TEMPLATE.md` file. The change updates the instructions for adding a new chain by specifying that the RPC URL will be taken from the `ethereum-lists/chains` repository.

* [`.github/PULL_REQUEST_TEMPLATE.md`](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L3-L12): Updated the instructions to clarify that the RPC URL will be sourced from the `ethereum-lists/chains` repository.
* `bin/github-review.sh`: Updated how RPC is fetched (Before: from PR description. After: from `ethereum-lists`).