### PR TITLE
feat: add 1.4.1 canonical contracts for HashKey Chain Testnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -15,6 +15,7 @@
     "81": "canonical",
     "88": "canonical",
     "100": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "196": "canonical",
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -15,6 +15,7 @@
     "81": "canonical",
     "88": "canonical",
     "100": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "196": "canonical",
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -15,6 +15,7 @@
     "81": "canonical",
     "88": "canonical",
     "100": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "196": "canonical",
     "314": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -26,6 +26,7 @@
     "97": "canonical",
     "100": "canonical",
     "114": "canonical",
+    "133": "canonical",
     "137": "canonical",
     "155": "canonical",
     "169": "canonical",


### PR DESCRIPTION
HashKey Chain Testnet

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 133

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
RPC_URL: https://hashkeychain-testnet.alt.technology/

Relevant information:
Block explorer: https://hashkeychain-testnet-explorer.alt.technology/