### PR TITLE
Feat: Add canonical address for ink mainnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "60808": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -247,7 +247,7 @@
     "56288": "eip155",
     "57000": "eip155",
     "57054": "canonical",
-    "57073": "eip155",
+    "57073": ["eip155", "canonical"],
     "58008": "canonical",
     "59140": ["canonical", "eip155"],
     "59144": ["canonical", "eip155"],


### PR DESCRIPTION
Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 57073

Relevant information:
The contracts are deployed and I have checked that canonical addresses have non-empty code.