### PR TITLE
feat: add Horizen Gobi Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -32,6 +32,7 @@
     "1101": "canonical",
     "1337": "canonical",
     "1516": "canonical",
+    "1663": "canonical",
     "1750": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -32,6 +32,7 @@
     "1101": "canonical",
     "1337": "canonical",
     "1516": "canonical",
+    "1663": "canonical",
     "1750": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -32,6 +32,7 @@
     "1101": "canonical",
     "1337": "canonical",
     "1516": "canonical",
+    "1663": "canonical",
     "1750": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -65,6 +65,7 @@
     "1442": "canonical",
     "1516": "canonical",
     "1625": "canonical",
+    "1663": "canonical",
     "1729": "canonical",
     "1750": "canonical",
     "1811": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1663

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://gobi-rpc.horizenlabs.io/ethv1

blockexplorer: https://gobi-explorer.horizenlabs.io/

deploying "SimulateTxAccessor" (tx: 0x4fef8ab61aa8f69a53c1f74095bcf252b0d43eba557d75b7f9a4559819b92f9f)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x8592a31282cc9bbee870537abddbc678e4bce69fdbddb7f7a3d3e3251710255a)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0xf64abc9e8bd0aacf4b6c6b09917a0c98c7e5e0dc3eb923cdbb00bcb95ee6a9d8)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0x85f82a5447748d6d231079da810ccaf52a7f4de759f1d343543647df87d2ce53)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x78a555d4c578720695138e4106fc19f307b888406f59826c4a378329351b5001)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x7132f2d45991a6df7de980ae4417c21e70bc60ba662311b2810b04fc4b726d65)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0x9ed18a29cc5af072eae5cad900f8a98e23d0402cb2249363f45d4f005982153d)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0xb45f417da6aa788f8190bcba6779931663e5792d813b67c859289057e5bf1dd0)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x440c0744e9f2fadf4ba2e1cdf5696496713dfcda2f5ccd68fee88eaebd3e7e6c)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0xf241a170c0d6ad74568c09edceadaeb233874251d969562b25734897a32f3664)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x29dd6287135b83f1a209579f560cfb0c3a599f0a853f3dfa45f4697e81b681b7)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0xf474286a1e157567acd98d0aaea2c8ae4eb93df957bb33bc1169425756682180)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x01a96e699def158a5349c4d3edd07efe43f8ac292e0aa06d211c81e4d8040d8c)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
