### PR TITLE
feat: add opBNB Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -44,6 +44,7 @@
     "4661": "canonical",
     "5000": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "7200": "canonical",
     "8217": "canonical",
     "8453": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -44,6 +44,7 @@
     "4661": "canonical",
     "5000": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "7200": "canonical",
     "8217": "canonical",
     "8453": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -44,6 +44,7 @@
     "4661": "canonical",
     "5000": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "7200": "canonical",
     "8217": "canonical",
     "8453": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -95,6 +95,7 @@
     "5000": "canonical",
     "5003": "canonical",
     "5115": "canonical",
+    "5611": "canonical",
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 5611

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://opbnb-testnet-rpc.bnbchain.org

blockexplorer: https://opbnb-testnet.bscscan.com/

deploying "SimulateTxAccessor" (tx: 0x8f9529bf09a839757f592963a5e8e975498470c4dae3b459baa570b33a23d63d)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0xf17bcefe6d6d36fa8ab20fc972802fd9e3356097ed85e09ff610c968e03b64ee)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x5b2d29fc14765ab9c846acebf8abc0a957bd69ba1bfb45bf3c2390826b5c910c)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0x6e5d33f6311c5add0c159d2fe63baca6ce5ee8078263dbaf08555b2cb84cde5c)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x6233822bd6c5781e108249701977366d1338b3dc11a45900d7bb5900d8239a6a)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x34bc67e33785386a97d8fedfebad2edf7d0a86b378936de3dc6c95283ed64ef8)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0x5cb548e0a96b0e91100abb9d48d4da0f4be7a07c56898fa8e84d61a3a70f0943)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x64b143c130022c32d98a643e2e48164cd5a2ddb61ef788492eb9a95153351083)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x073c64aea709b2c3099c6fa932b8cc4ddc9a622a43b6c997a6dc77e5662ac8f0)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0xb63ce4ac36e195aafa1e7adcc5bdeeedec75f20b9f34a8ef3d8e233f46a32fcc)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x47f2d4e6feeafbf2368096c0fa473871877b82a71d46cc48c7fa42b8b65bd59f)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x8d7ac277a789303e6dee909923ef18bfc97df9671773e4c3d12f2604219ba22b)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0xc39749aab015684bebf688b8e67ae5c8d1fa8daa04d0400d15b50406f086eead)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
