### PR TITLE
feat: add Rollux Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -58,6 +58,7 @@
     "43111": "canonical",
     "43114": "canonical",
     "44787": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59144": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -58,6 +58,7 @@
     "43111": "canonical",
     "43114": "canonical",
     "44787": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59144": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -58,6 +58,7 @@
     "43111": "canonical",
     "43114": "canonical",
     "44787": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59144": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -139,6 +139,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "54211": "canonical",
+    "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",
     "59140": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 57000

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://rpc-tanenbaum.rollux.com

blockexplorer: https://rollux.tanenbaum.io/

deploying "SimulateTxAccessor" (tx: 0xe0806197d6d4b17eb5c594b5c2210c39ae49f6b5c2c6f23d6d4188e8a737586c)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
deploying "SafeProxyFactory" (tx: 0x58bdfc55bd3d0a8a4f2f1c874e9649ceed54b3b2cb6565c337cfeefc1e89a51c)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712428 gas
deploying "TokenCallbackHandler" (tx: 0x2002fdee12b49836c6f2cd425cd777704c2c55fe3dc7a5fd2f5c966a4cef08dc)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
deploying "CompatibilityFallbackHandler" (tx: 0xe927f0529a1fa3481c1bafac2fc951d502683e6cd09b5231ddb14b07be536402)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1269776 gas
deploying "CreateCall" (tx: 0xf6a2ead00d364c8375cab09636b24fcd32223bc3d1f1762d9b6b44e463399d0d)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
deploying "MultiSend" (tx: 0xea2b42f68469e7740dd4e4216e5cff1f84b32956ad8a7c0d135230ec4dac4bcf)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190016 gas
deploying "MultiSendCallOnly" (tx: 0xf46953a6fab056c50c97763c9831a857d4a9c02ec9502a3160edc3640d19e93b)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0x3615fd67c8202e2cd123266b4c23baa96a1f47e915fb7725817770e6daf75b58)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0x34d4f9a091d43a39e4e183dde0663427d9458d45a29ed5a324fa5ef90858ed17)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0x6c4b523c1e14e3573e95e853fe3c7db3c89a83e9d70dad226d5ee9fce59c6bc2)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
deploying "SafeL2" (tx: 0xa399ef6d3e32efe4347a7d37d1e5bdc9711e8bd4bcc7a2ef7507fe52477e348d)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5331001 gas
deploying "SafeToL2Migration" (tx: 0xe5c45dc421403fe7479138baabd1966519d0f8829f8878514ac21b5693b5ff31)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0xb27876a77a767e487d3dac5d78ff61b6c20f975fc65e09da438efa7f42ff2f41)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas
