### PR TITLE
Feat: add taker chain mainet 1.4.1 vertion contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -30,6 +30,7 @@
     "995": "canonical",
     "1001": "canonical",
     "1101": "canonical",
+    "1125": "canonical",
     "1337": "canonical",
     "1516": "canonical",
     "1663": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -30,6 +30,7 @@
     "995": "canonical",
     "1001": "canonical",
     "1101": "canonical",
+    "1125": "canonical",
     "1337": "canonical",
     "1516": "canonical",
     "1663": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -30,6 +30,7 @@
     "995": "canonical",
     "1001": "canonical",
     "1101": "canonical",
+    "1125": "canonical",
     "1337": "canonical",
     "1516": "canonical",
     "1663": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -56,6 +56,7 @@
     "1101": "canonical",
     "1111": "canonical",
     "1112": "canonical",
+    "1125": "canonical",
     "1135": "canonical",
     "1284": "canonical",
     "1285": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1125

Relevant information: 
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://rpc-mainnet.taker.xyz

blockexplorer: https://explorer.taker.xyz

reusing "SimulateTxAccessor" at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
reusing "TokenCallbackHandler" at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
reusing "CreateCall" at 0x9b35Af71d77eaf8d7e40252370304687390A1A52
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
reusing "SignMessageLib" at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9
reusing "SafeToL2Setup" at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
reusing "SafeToL2Migration" at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69
reusing "SafeMigration" at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6