### PR TITLE
[New chain]: Arthera Mainnet for v1.4.1

### DIFF
--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -53,6 +53,7 @@
     "8453": "canonical",
     "9700": "canonical",
     "10081": "canonical",
+    "10242": "canonical",
     "13746": "canonical",
     "33139": "canonical",
     "42161": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -53,6 +53,7 @@
     "8453": "canonical",
     "9700": "canonical",
     "10081": "canonical",
+    "10242": "canonical",
     "13746": "canonical",
     "33139": "canonical",
     "42161": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -53,6 +53,7 @@
     "8453": "canonical",
     "9700": "canonical",
     "10081": "canonical",
+    "10242": "canonical",
     "13746": "canonical",
     "33139": "canonical",
     "42161": "canonical",


### PR DESCRIPTION
Provide the Chain ID (Only 1 chain id per PR).

- Chain_ID: 10242

Version of contracts deployed
v1.4.1

Logs
```bash
reusing "SimulateTxAccessor" at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
reusing "TokenCallbackHandler" at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
reusing "CreateCall" at 0x9b35Af71d77eaf8d7e40252370304687390A1A52
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
reusing "SignMessageLib" at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9
deploying "SafeToL2Setup" (tx: 0x3e5e658f72d8ed02dbd77bcb5e56676a0f528b2f07fdf7ddc68bda9aeef2fb02)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 231061 gas
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
deploying "SafeToL2Migration" (tx: 0x48599f2a941f85030c43fc9ac9c5f9ea267e8317723baeb322fe796287da0655)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1284521 gas
deploying "SafeMigration" (tx: 0xee9841888dab68061022b8bd94c12a69e858ad2a26236c2b4b6d273d998e3363)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 513331 gas
```