### PR TITLE
[New chain]: Planq Network for v1.3.0

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -179,6 +179,7 @@
     "6398": "eip155",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
+    "7070": "canonical",
     "7332": "eip155",
     "7341": "canonical",
     "7560": ["canonical", "eip155"],


### PR DESCRIPTION
Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 7070

Relevant information:
Block explorer: [https://evm.planq.network/](https://evm.planq.network/)
ethereum-lists: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-7070.json

Version of contracts deployed
v1.3.0