### PR TITLE
feat: add inEVM Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -44,6 +44,7 @@
     "1923": "canonical",
     "1924": "canonical",
     "2187": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2818": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -44,6 +44,7 @@
     "1923": "canonical",
     "1924": "canonical",
     "2187": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2818": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -44,6 +44,7 @@
     "1923": "canonical",
     "1924": "canonical",
     "2187": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2818": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -83,6 +83,7 @@
     "2187": "canonical",
     "2192": "canonical",
     "2358": "canonical",
+    "2424": "canonical",
     "2442": "canonical",
     "2810": "canonical",
     "2818": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2424

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://testnet.rpc.inevm.com/http

blockexplorer: https://testnet.explorer.inevm.com/

deploying "SimulateTxAccessor" (tx: 0xbb2bdd7b6dcdb77f421beab38907848aa66ee9f4c9952ba88bbcfbb8b7f0aee1)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 4566169 gas
deploying "SafeProxyFactory" (tx: 0x8988aa917f36a9f0244e5d796f46819a178ee2e92848e2d4c14f50d5c2fa31c0)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 8708215 gas
deploying "TokenCallbackHandler" (tx: 0x721417c4cd8aa844523b15e2f74a8f5e760837f5b66c061b083c55a23992a075)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 4575795 gas
deploying "CompatibilityFallbackHandler" (tx: 0xc6d380647e29df22987a503c9c2e48b86316e4bf8964e052f9adacce6691f208)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 11893004 gas
deploying "CreateCall" (tx: 0x3146758a6c2e463033bdd2d816d1691a56dff2bf252be4d680ee0724766fcd70)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 4082418 gas
deploying "MultiSend" (tx: 0xf399461c347d549b3d4c4f58194c725895e625f3725305ffb737b5e1965565be)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 3954925 gas
deploying "MultiSendCallOnly" (tx: 0x28981b23bf2026f2ae261d0f3d0efefb2d48f41766eb8af0329f71c3e6df8dae)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 3164874 gas
deploying "SignMessageLib" (tx: 0x8bf53132d21d8af88131935bcd1bfa5e11ac62b4cf5d6a51254fc506db2c319f)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 4520233 gas
deploying "SafeToL2Setup" (tx: 0xe3cd2f128cd53252d4f938af864d59fd9c05d912f9f0caed04ae6c39037ae4c0)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 4114901 gas
deploying "Safe" (tx: 0xb4fa11d8ff535a9efc02013eef321e7c8d71e3569f04ee11a9e5feb2d6bd1eec)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 37880003 gas
deploying "SafeL2" (tx: 0xa14353665e0c954c5fa895803c8d0821188e5a7f7d0c366160d7f187da4cfe00)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 39400478 gas
deploying "SafeToL2Migration" (tx: 0x9b3f394b2c9c41aaa439d0a40cb0264e2057afb80519cd6763d0c392890949b3)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 11943869 gas
deploying "SafeMigration" (tx: 0x29cf74086885db2e2d303986f498eba6e1797b3d2e58162839ea57334f256507)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 6845411 gas
