### PR TITLE
[New chain]: Hyperliquid for v1.3.0

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -111,6 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
+	"999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -111,7 +111,7 @@
     "787": "eip155",
     "919": ["canonical", "eip155"],
     "943": "canonical",
-	"999": "canonical",
+    "999": "canonical",
     "1001": "eip155",
     "1008": "canonical",
     "1030": "canonical",


### PR DESCRIPTION
Provide the Chain ID (Only 1 chain id per PR).

- Chain_ID: 999

Version of contracts deployed
v1.3.0

Logs

```bash
reusing "SimulateTxAccessor" at 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da
reusing "GnosisSafeProxyFactory" at 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2
reusing "DefaultCallbackHandler" at 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd
reusing "CompatibilityFallbackHandler" at 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4
reusing "CreateCall" at 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4
reusing "MultiSend" at 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761
reusing "MultiSendCallOnly" at 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D
reusing "SignMessageLib" at 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2
deploying "GnosisSafeL2" (tx: 0x2845931ddf596e21d09830d8c1a3257b60a9b3296f65753e7c2ac9cfad834541)...: deployed at 0x3E5c63644E683549055b9Be8653de26E0B4CD36E with 5201733 gas
deploying "GnosisSafe" (tx: 0x8ca524ed5be0fbd74d56001aac9e7f389ed0f33341e77227232eb0c7e7a9f253)...: deployed at 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 with 5019271 gas
```