### PR TITLE
fix: Rename asserthighestChainIDChanges to assertHighestChainIdChanges

### DIFF
--- a/scripts/review/diff.ts
+++ b/scripts/review/diff.ts
@@ -53,7 +53,7 @@ function hasChangeTypes(changes: parseDiff.Chunk['changes'], types: string[]): b
  *
  * @param changes The changes in the diff patch.
  */
-function asserthighestChainIDChanges(changes: parseDiff.Chunk['changes']) {
+function assertHighestChainIdChanges(changes: parseDiff.Chunk['changes']) {
   assert(hasChangeTypes(changes, ['del', 'add', 'add']));
   assert(changes[0].content.replace(/^-(.*)/, '+$1,') === changes[1].content);
 }
@@ -119,7 +119,7 @@ async function main() {
     // Check to see if the changes are valid and set any edge case flags.
     const changes = chunks.flatMap(({ changes }) => changes.filter(({ type }) => type === 'add' || type === 'del'));
     if (additions === 2 && deletions === 1) {
-      asserthighestChainIDChanges(changes);
+      assertHighestChainIdChanges(changes);
     } else if (additions === 1 && deletions === 1) {
       additionalDeploymentToSameChainId(changes);
     } else if (additions !== 1 || deletions !== 0) {


### PR DESCRIPTION
- Fix function name to follow TypeScript naming conventions
- Use consistent camelCase style