### PR TITLE
feat: add Metal L2 Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -41,6 +41,7 @@
     "1337": "canonical",
     "1516": "canonical",
     "1663": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -41,6 +41,7 @@
     "1337": "canonical",
     "1516": "canonical",
     "1663": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -41,6 +41,7 @@
     "1337": "canonical",
     "1516": "canonical",
     "1663": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -74,6 +74,7 @@
     "1625": "canonical",
     "1663": "canonical",
     "1729": "canonical",
+    "1740": "canonical",
     "1750": "canonical",
     "1811": "canonical",
     "1923": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1740

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL:  https://testnet.rpc.metall2.com

blockexplorer: https://testnet.explorer.metall2.com/

deploying "SimulateTxAccessor" (tx: 0xa0b0750f18e65191e7849ac8038fb2b33cb28b417dd806c673d6bf1058b05d1d)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x1283c5a332ba0822b4a74630c83f5d18cad9a89d582432348b68580819b811bf)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x5748bfd85c0cc2a14a72c27351d7e4b8d37f5f0b3a07a5cf451f7d4a07aec777)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xbeb49fddbd37af77dee3c3178056f81fa16eebc2f31fa0771e0c124357e700ee)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0xcedf3b116d711a24ee6b63dbfe56e5c638c7f8a5e06dc362ffa8f2658f54a85b)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0xce3fa7583bcb8a55fd94fc1105aeada6b245eedd6cfdfb2f716c6f15502d8c0a)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0xd98657c4479199bb059e56499758ccaac8ff697cbd57a2e079bdbd2ccd57a770)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x643477e17d955b43dc29ba6a533a677a7965c81b61011930ed4cf5c957939d6f)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x9bf10ea3b20f47c698af169bcd3a27599a041693c4435d1f5bd2e356b164ab5a)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x27673873ab04cfd5df5a3e967ed3d5e265eada31924876dd28f1e1982c5866ec)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x71520c8f2a49bec85c4d82c3ddc872d243295c0ffe3df7f7c4ddefa64ef805b2)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x74aed3e6385c50f588f7cacc6cbb9f7557f65dbd4bde90a125e470c2c25c443b)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0xa811c052ea32a6b278f75ba52a366e35363104bfb701f590a74821974b4e3b62)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas