### PR TITLE
feat: add Superseed Sepolia Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -71,6 +71,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -71,6 +71,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -71,6 +71,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "57000": "canonical",
     "57054": "canonical",
     "57073": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -149,6 +149,7 @@
     "43114": "canonical",
     "44787": "canonical",
     "47763": "canonical",
+    "53302": "canonical",
     "54211": "canonical",
     "57000": "canonical",
     "57054": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 53302

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://sepolia.superseed.xyz

blockexplorer: https://sepolia-explorer.superseed.xyz/

deploying "SimulateTxAccessor" (tx: 0x3dd45e9ff64590e6092f0c2b2c7057a407e68095a906841584a8e2858f77ca75)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x95f9f3e9bd67a8378877f2f0d58eb25f31e2ad1bd11b1aee46b20cf2f597bf38)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x62f7fb18718ddbf62ead59610d1ef39ef8e0129537b7c19c24c6ff91b4466206)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xbc108d74924b2d77dde4374d85454ba3501f60e5f8c499214c6efa98b38668d4)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0xad8c38cb64c8e2a8ab6baf3ef674938d73c11a48b60446e332630a0dd853e42b)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x64315f63c6c40ed1e79dafcbcc3f545082b66cc26fc77214b664adc499261db2)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0x1fe1e01dca3a45c2518498ddf5e9e06c57814677bdc471f8201bd6b2b30e7b35)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x03b29d5c8a4061c1f30c017e9e55b0e996379d4ac107372d9e33580b1b43343e)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0xbc3771d3864d0bed581670afb5f590e081c6f91dfa302406ea18ba1ffa75160d)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x3de06bfcfaa41f3ce0a5a3317e19c26ed86b336376044faeb426512df35a01d8)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0xd90716fe0cc516edfdbcf6700fcea7a559408605918d60da174342faa72b0732)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x768928c1ca742ac4996e416de0ba169744aa8fff8d0c7ad2f0523f727a9254f3)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x33c4d59a4084072b4ae0c8d9a5bd04f475456e9cac78178e998a2ff6968eb1e2)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas