### PR TITLE
Add Okto Testnet Network 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -59,6 +59,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9369": "canonical",
     "9700": "canonical",
     "10081": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -59,6 +59,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9369": "canonical",
     "9700": "canonical",
     "10081": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -59,6 +59,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9369": "canonical",
     "9700": "canonical",
     "10081": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -120,6 +120,7 @@
     "8217": "canonical",
     "8408": "canonical",
     "8453": "canonical",
+    "8801": "canonical",
     "9001": "canonical",
     "9369": "canonical",
     "9700": "canonical",


### PR DESCRIPTION
## Add new chain

Okto Testnet

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 8801

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).
- RPC_URL: https://rpc.okto-testnet.zeeve.online

Relevant information:
- Block Explorer:  https://explorer.okto-testnet.zeeve.online

#### Deployed contracts details

deploying "SimulateTxAccessor" (tx: 0x9b100aa697472783a1fe8689aac53acbc49fba2006873c72b7e2712e7b65fec6)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0xd6602f12b8f95b54c555d801b0c34834efdf1b1a53285412756bdd1ed2d6771d)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0xa9afbcbca1ce0994e297a36773c20fd51927e6babef3eb3bc8478c8e50acf322)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0x32c29082f405eb7dee49e818051d6d77ba09863d5e60a631f6a1284c6f37b560)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x5a925fd10ff67d1ec82d19e5431343545b4b4dc37031328e779a484a64a18be9)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x60bb75e42378d15095341f5e5cf8784430b59ea3aeb881e170bf35c1114bacca)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0x9b822749744e5f20a34bcff5c9be139246b0b6f93ebce9d5895293bad783b859)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0xb2e27498966bcee398be9ad1fd9740e89bbf690c1b67a934be09bdfd071a84e2)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x2252f88d9176360b37e03a78505172471dd76bef06e3610e5c9d90fff7eb1ea3)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x53fe7384304ca3860239ef2aa9a026e38a3c24437ae9210a0edba3472cab075e)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0xf1598ef19f0c3410746d2885e2c3a69d57e58a439a0ec6ca067a091c92017d32)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x3fe618283604f731f322be2d9375e474d03f59bad6569ab778dbe5c566e85966)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x45fb8c6d5ab18816837d744bb3fb62fbfa8dad73affb6ec98af03cae04261b18)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas