### PR TITLE
feat: add Metis Sepolia Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -81,6 +81,7 @@
     "57054": "canonical",
     "57073": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80094": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -81,6 +81,7 @@
     "57054": "canonical",
     "57073": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80094": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -81,6 +81,7 @@
     "57054": "canonical",
     "57073": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80094": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -162,6 +162,7 @@
     "59140": "canonical",
     "59141": "canonical",
     "59144": "canonical",
+    "59902": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 59902

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://metis-sepolia-rpc.publicnode.com

blockexplorer: https://explorer.metis.io/

deploying "SimulateTxAccessor" (tx: 0x978eeb68f30f7b2be28f72095dd0336d719037babe69452249042612dc7690e1)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
deploying "SafeProxyFactory" (tx: 0x41688254f10b7e85a9fcf061db3a7669a95d5a1afae31bd77db24131fd514ff4)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712428 gas
deploying "TokenCallbackHandler" (tx: 0x13a67ebfa3b03bf43f15ddcdf88683dfb2e4a656bf77134279274306f18b64fb)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
deploying "CompatibilityFallbackHandler" (tx: 0xd91b390c27f54045ffc504c7df6b0acccecbe1ccc5d621ca6b041399908b84a4)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1269776 gas
deploying "CreateCall" (tx: 0x682d2255b982366e932e9f2e209a5af5720e9879f0aab51c7d3782ad3bd6da6d)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
deploying "MultiSend" (tx: 0x15745082b4a20c8446d3e8f1431d5d90623093a52da998cc650484b7e8223860)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190016 gas
deploying "MultiSendCallOnly" (tx: 0x31a21c97862ded3c52383840b35801277fd84434c5726e7b72216af2691caf9f)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0xee5d38072efae502220a72181e0c0301b95181dc60d123e255e976d3af3fd020)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0x39547a6e1d92fd96f2effae62fd36d70ddb13c3eec0eeee178ee88ff68f7d2ef)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0x17627c019f51b6bb5188b39a091ad429472d4eadabf845f8a5cd2981b84310ce)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
deploying "SafeL2" (tx: 0xc27de303ee8d70107ff5b310ec2ab846e2a6462435ea2659f75a7cb679f80618)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5331001 gas
deploying "SafeToL2Migration" (tx: 0x7ddee511eebda5ee32ff31bf4c0ed3db86e5b2a274191da821ccf4a1639e16ce)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0x69e3f8a2cac48ad76ba3c206b0eef7d9e5d0c0501ba9c00f3f73972f59c18618)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas