### PR TITLE
feat: add Lumia Mainnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -98,6 +98,7 @@
     "11155111": "canonical",
     "12227332": "canonical",
     "253368190": "canonical",
+    "994873017": "canonical",
     "1313161554": "canonical",
     "1417429182": "canonical",
     "1570754601": "canonical"

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -98,6 +98,7 @@
     "11155111": "canonical",
     "12227332": "canonical",
     "253368190": "canonical",
+    "994873017": "canonical",
     "1313161554": "canonical",
     "1417429182": "canonical",
     "1570754601": "canonical"

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -98,6 +98,7 @@
     "11155111": "canonical",
     "12227332": "canonical",
     "253368190": "canonical",
+    "994873017": "canonical",
     "1313161554": "canonical",
     "1417429182": "canonical",
     "1570754601": "canonical"

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -205,6 +205,7 @@
     "253368190": "canonical",
     "476462898": "canonical",
     "666666666": "canonical",
+    "994873017": "canonical",
     "999999999": "canonical",
     "1313161554": "canonical",
     "1313161555": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 994873017

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://mainnet-rpc.lumia.org

blockexplorer: https://explorer.lumia.org/

deploying "SimulateTxAccessor" (tx: 0xf642ad98fc0f28f17925b1e8aa2fd0f400ba92ea3b6145db2f3e863e1a2bdd54)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
deploying "SafeProxyFactory" (tx: 0x3acf60a1bb23e41435452b1b49808107341ea0d5aa7e72dcbf27470191d1af4e)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712428 gas
deploying "TokenCallbackHandler" (tx: 0x424500de0633441f5333cf772ca495d0a5169d0a2ded3a3b12e6e1fa9776e2a8)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
deploying "CompatibilityFallbackHandler" (tx: 0x9fd58968c811bc151ba298fab59787d5a843d321a2cf078370123ef87959860c)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1269776 gas
deploying "CreateCall" (tx: 0xa62312ced56e7df1772d28945885fa832cc4dbedc10202178ac98b3f95c7cd03)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
deploying "MultiSend" (tx: 0x2cbf8f620f390f5bfc69cce614d21917f7cc9288436781922ba1de5cba81338a)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190016 gas
deploying "MultiSendCallOnly" (tx: 0x691bdc1f5293363da66205c716ac6228a5fbe78cbb003a270b1a7917942ea56b)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0x3b4ed96dbbca27fcf410ee7650524893d67fc281236d5fe217fbae07ba7b4bcb)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0x966905a1e52855b0e79ed44c4da4fc11937b3b1eae2eb2966769377d39fce543)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0x16b3177b3b8ea08160ef65358f674ee2cd8c59a5592245bb28092eb147737170)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
deploying "SafeL2" (tx: 0xe3599ab5bc4e9b035a5af2a34be42bbffa19b70e8f25f89f488a0f6b483ac28b)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5331001 gas
deploying "SafeToL2Migration" (tx: 0xdeb61a6bb8657855bc20f398e5177444fb44a8ff7547ce31353d7d44154c2bd0)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0x19de9f59d1e611e220379ef0b2b010b4a2bb650a00620848de365b94baa024f7)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas