### PR TITLE
feat: add Lumia Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -100,7 +100,8 @@
     "253368190": "canonical",
     "1313161554": "canonical",
     "1417429182": "canonical",
-    "1570754601": "canonical"
+    "1570754601": "canonical",
+    "1952959480": "canonical"
   },
   "abi": [
     {

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -100,7 +100,8 @@
     "253368190": "canonical",
     "1313161554": "canonical",
     "1417429182": "canonical",
-    "1570754601": "canonical"
+    "1570754601": "canonical",
+    "1952959480": "canonical"
   },
   "abi": [
     {

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -100,7 +100,8 @@
     "253368190": "canonical",
     "1313161554": "canonical",
     "1417429182": "canonical",
-    "1570754601": "canonical"
+    "1570754601": "canonical",
+    "1952959480": "canonical"
   },
   "abi": [
     {

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -213,6 +213,7 @@
     "1570754601": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
+    "1952959480": "canonical",
     "88153591557": "canonical",
     "123420000220": "canonical"
   },


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1952959480

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

RPC_URL: https://testnet-rpc.lumia.org

blockexplorer: https://testnet-explorer.lumia.org

deploying "SimulateTxAccessor" (tx: 0x3495415255f12e27ae3e6ef9146e9a6e82dbc79d843bc0949f28000a2965d2cd)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
deploying "SafeProxyFactory" (tx: 0x6bdaa21d3a0fd09af4fd81099efea352892a54a64000411107798fb41a5db44f)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712428 gas
deploying "TokenCallbackHandler" (tx: 0xff92bfa750023ffc77d04c17a46716bd7c71bc2874cfab69c8eba43b463f24b1)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
deploying "CompatibilityFallbackHandler" (tx: 0x07ab6d7726506674c45d67b441dc74d94f2daa769490b4a777e5913b227513c4)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1269776 gas
deploying "CreateCall" (tx: 0x5ea50dfa24854d7c61bf9e8648f315bb5e2f7e7fe3fd3f2b8b57ef54709f3146)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
deploying "MultiSend" (tx: 0x77a5b95dede10d5207b112b4b50296e3e3a59bcc3db1f6cf42fdfaff5ac8ddef)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190016 gas
deploying "MultiSendCallOnly" (tx: 0x81836c2f5d60c5392d51f5b80d163296bdf4f609c0a999d571062facf6ca3ad8)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0xf57631976163b127acc408b1c25879dc58bc36ab8cffc089e0a0cf686250bca3)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0xebfee88b84737b370ed53820999e659ddaa2fbd5f4192e19414c9cb4b8ad0442)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0xb539891b9857814d2dfade5c5502342837d2b1c8012e060c9f7768f1f59aecbf)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
deploying "SafeL2" (tx: 0x7c8286c313e33263b1f286be7a959ebc379aa75061d2b8b757aff9f5a2aebaff)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5331001 gas
deploying "SafeToL2Migration" (tx: 0x21712b6b2654b5b655a803989308b49b358a18ef8e74c2ea9dfd1fabbf45194e)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0xe39683f6b6f32be232ee531fe2e4bbc701881b0d54bd9cebf9a28f6939d3c9ce)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas