### PR TITLE
feat(v1.2.0): add PulseChain (Chain ID: 369) as a supported network

### DIFF
--- a/src/assets/v1.2.0/gnosis_safe.json
+++ b/src/assets/v1.2.0/gnosis_safe.json
@@ -16,6 +16,7 @@
     "88": "canonical",
     "100": "canonical",
     "246": "canonical",
+    "369": "canonical",
     "73799": "canonical"
   },
   "abi": [


### PR DESCRIPTION
- Chain_ID: 369

This PR adds PulseChain (Chain ID: 369) as a supported network for Safe v1.2.0.

Why is this needed?
PulseChain is a full-state copy of Ethereum, meaning all Safe contracts already exist on the network. However, older Safe wallets on PulseChain cannot currently be used, as they are not officially recognized by Safe's deployment records.

Changes in this PR:

- Added PulseChain (369) to Safe v1.2.0 using the "canonical" deployment model.
- Reused Ethereum Safe contract address (since PulseChain is a full-state copy).
- Validated deployment with npm run review:verify-deployment 
- Ensured JSON structure follows Safe repository guidelines.

Network Details:

- Chain ID: 369
- RPC URL: https://rpc.pulsechain.com/
- Block Explorer(s): https://otter.pulsechain.com/ and https://scan.pulsechain.com/

This PR allows existing Safe wallets on PulseChain to be properly recognized. Please review and merge if everything looks good! 

Why This Version?
- This version only modifies Safe v1.2.0.
- Separate PRs will be opened for v1.0.0 and v1.1.1.
