### PR TITLE
feat: add EXPchain Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -72,6 +72,7 @@
     "10242": "canonical",
     "11011": "canonical",
     "13746": "canonical",
+    "18880": "canonical",
     "33139": "canonical",
     "42161": "canonical",
     "42220": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -72,6 +72,7 @@
     "10242": "canonical",
     "11011": "canonical",
     "13746": "canonical",
+    "18880": "canonical",
     "33139": "canonical",
     "42161": "canonical",
     "42220": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -72,6 +72,7 @@
     "10242": "canonical",
     "11011": "canonical",
     "13746": "canonical",
+    "18880": "canonical",
     "33139": "canonical",
     "42161": "canonical",
     "42220": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -141,6 +141,7 @@
     "17000": "canonical",
     "17069": "canonical",
     "18233": "canonical",
+    "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
     "32769": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 18880

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

blockexplorer: https://blockscout-testnet.expchain.ai/

RPC_URL: https://rpc1-testnet.expchain.ai

sending eth to create2 contract deployer address (0xE1CB04A0fA36DdD16a06ea828007E35e1a3cBC37) (tx: 0xe0a93c1a42942c4de6e993eb2a559a32f819b983a45edf596a8f0023eae7177b)...
deploying create2 deployer contract (at 0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7) using deterministic deployment (https://github.com/Arachnid/deterministic-deployment-proxy) (tx: 0x3978c84a6d3b971eadf9a5fb3b0da63bc4f20bfb4124ab0a3e48db63568ea67b)...
deploying "SimulateTxAccessor" (tx: 0xe80cd6f21bf0fddfe9917c5a8ddc7a9ac7c498f8256f720681de845bc2fccd58)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x631c51727b0d77f951913cf3a34153be7c54aaca95ad9b82eb7185300c5a2de1)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x0012c23cb4e6de19c074300d2a8e75b7bb45c5a444fdbfb940b6c562aacb8940)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xa8a5af40f5d12417aa90082165326dafd0cebaf1cfe0967edbab17ea874c5192)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0xd5981a1c9bfaaa7d7fb82258426a9abfca7c1750c2f157f7e0053d591a2ded44)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x1544853e20399278319f033a93bb0c8930d52b5ea0f9be942f1311a09f5549a0)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0x02db2294726af6aa9f34dac870075c9d2606dd2c046128b8bfb6693a24e99e9b)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0xad47d52a28961c4d6f8ef3559e74a6382863e6ad213df6a14fb960e9def1ad96)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0xf6ea0d5046cd7e0ed093fafeddaa45ff3ca927aeff95fc339b54a00f3ae80087)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x34b1c39b437ee03c7c4a65ae611289d552e604de8b40709ee843b9dca6102122)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x900cdb04e02bee7df6a57174e7568304d0d52c70cbe5e26d2bbaf175f9c47bc7)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x541abffa372c36e4fdeb32ba48d02f67fafcee8681bb624089cb4efa0257fb4e)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x49ee82a0ce860b8a23e3cdb9d6fce02b1d58d7c74013d6bfdcacc35ec4930976)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas