### PR TITLE
feat: add MegaETH Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -69,6 +69,7 @@
     "5000": "canonical",
     "5115": "canonical",
     "5611": "canonical",
+    "6342": "canonical",
     "7200": "canonical",
     "8217": "canonical",
     "8408": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -69,6 +69,7 @@
     "5000": "canonical",
     "5115": "canonical",
     "5611": "canonical",
+    "6342": "canonical",
     "7200": "canonical",
     "8217": "canonical",
     "8408": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -69,6 +69,7 @@
     "5000": "canonical",
     "5115": "canonical",
     "5611": "canonical",
+    "6342": "canonical",
     "7200": "canonical",
     "8217": "canonical",
     "8408": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -121,6 +121,7 @@
     "6001": "canonical",
     "6321": "canonical",
     "6322": "canonical",
+    "6342": "canonical",
     "6688": "canonical",
     "7000": "canonical",
     "7001": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 6342

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

blockexplorer: https://www.megaexplorer.xyz/

deploying "SimulateTxAccessor" (tx: 0x96f78e045c04414d218e3669ceca62c5c2fb5601ce736c58d72abe212b4dd829)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
deploying "TokenCallbackHandler" (tx: 0x2e307a9ff3f5576fdf2efaa20283b394bad732e0415cdfc97f0feea05210952d)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
deploying "CreateCall" (tx: 0x734f3fb9312a46b0d543ec444b65709bb54ec3a5d15910ce657edd9f31a4fe43)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
deploying "SignMessageLib" (tx: 0x0f52bde70d3f43f16b9431e17260bb8d59fa8c47cae5ac2a869a45b0d900b901)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x4985aa1c2ea80b3398608562e2f3467a3cbd49248ece0361dd76b2103573ef53)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
deploying "SafeToL2Migration" (tx: 0xfdba3a78ca3c03102b5c371105ebacc1acba2eb36d4be6a7d05049552a75bfa3)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x5fbc73f14774d169b424514a4838f5014ad75b49b51a6dec0db5d7d5e49fd765)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
