### PR TITLE
feat: add Creator Chain Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -97,6 +97,7 @@
     "57073": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80094": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -97,6 +97,7 @@
     "57073": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80094": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -97,6 +97,7 @@
     "57073": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80094": "canonical",
     "81457": "canonical",
     "84532": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -177,6 +177,7 @@
     "59141": "canonical",
     "59144": "canonical",
     "59902": "canonical",
+    "66665": "canonical",
     "80001": "canonical",
     "80085": "canonical",
     "80094": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 66665

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

blockexplorer: https://explorer.creatorchain.io/

deploying "SimulateTxAccessor" (tx: 0x7e890632fb187036ea1d3c29949bfa7445e20c0b5f36dd01f681a15b62ac6465)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x948750062f3472da1864012e5a105ee41545179bd8a265ba46cf4d2f6232c822)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x40b84d46f2452ef18a526a8dc05991444176fe66bdc95a9ebf1813fcd872ba45)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0x10e394e784b685cc8c20390ff69af63a6932a99be186bfb5e275935df94258da)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0xfbfdc365b62bd6a9294eebd685cd5cd8dc9791c0670ab06492c4dbc0668455dd)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x5fe635e1d1f44b0c1ab3dec103770355dde764b35fba8af26b509c04c47290e9)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0xc66981151e96cb73544761e15d4d852609a72fb0192237d764da12230a591b98)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x602ccc7ab945e9e5a52e8996a9f844ae5eb6cef74cdebf7d4c4d029174083c25)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0xf1c0c7817f17685d680c0e299e72756b4dac672a57a6f53278a7b0439eaa9c31)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0xf13dd5502df1802d41ea382139012aeb197cc2ddfab36ba278414cc5ec0431cc)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0xf3667939cb4a76d842dd137a906a7dfd40e91ac997e7bb4fb8d1209e22adba25)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0xf83b7565a4ac75a5a7462ff4f810fd23674bcb33292ab1496a3d5434479b02e1)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0xd4b9937c088b450c87fc12e63d1ba8ded5364482893f73400dd91cc07d4b936c)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas