### PR TITLE
feat: add Status Network Sepolia 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -120,6 +120,7 @@
     "1313161554": "canonical",
     "1417429182": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1952959480": "canonical"
   },
   "abi": [

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -120,6 +120,7 @@
     "1313161554": "canonical",
     "1417429182": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1952959480": "canonical"
   },
   "abi": [

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -120,6 +120,7 @@
     "1313161554": "canonical",
     "1417429182": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1952959480": "canonical"
   },
   "abi": [

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -229,6 +229,7 @@
     "1417429182": "canonical",
     "1511670449": "canonical",
     "1570754601": "canonical",
+    "1660990954": "canonical",
     "1666600000": "canonical",
     "1666700000": "canonical",
     "1952959480": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1660990954

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

blockexplorer: https://sepoliascan.status.network

deploying "SimulateTxAccessor" (tx: 0x265e5d3c4c32c5c546837fc430578d90c8c82bf9f3e4a0d7bc261dea37514d24)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
deploying "SafeProxyFactory" (tx: 0x20298bcade1fd984f3ce5deba6e1d62f31bda2e252a9dfd8d899826325142f3b)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712428 gas
deploying "TokenCallbackHandler" (tx: 0x4d0312a53afa7fed144e35f0d2f345a311aa493a832c9d427abc48562850e340)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
deploying "CompatibilityFallbackHandler" (tx: 0xeea7411574ed96f0ca648335d385a98012689cf5e3c966ca79044e1d42d4673e)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1269776 gas
deploying "CreateCall" (tx: 0x367afdca268d45fbb81c007fdd918407d420cdbd4c40722e323de874e3ef45f0)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
deploying "MultiSend" (tx: 0x114f0bd3d8f2a35c8cf2a00b477ad384a3a3811ba183fb68b707e025c178ff63)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190016 gas
deploying "MultiSendCallOnly" (tx: 0xaadf9ea89d6077d46be84b0e43e6d9699e5f613f75b1c4d025942b74eba7de0b)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0xf182867a70027389e06fb3909cc1c261419153239b8a48be2db2951211e48a54)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0x29238360b5f85c2b8050cc753dbff4dbe4220bf1fe0209aff3f2400f4de8eacb)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0xc5edc73966cd27db59dc3c4a1952d8c40169aaafda6da0424500cba0284e2940)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
deploying "SafeL2" (tx: 0x8eba0091093091fa447256a7a87f019aaabed8f8af7ff4f1e9dbc69accd766f9)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5331001 gas
deploying "SafeToL2Migration" (tx: 0x2ab78ea7f81e1d81577f797fe8a7d9897fe3d8e176f6e4f69d1c0c8e17fb6c89)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0xe0eb22fa358556dac9df6396bb51260465f8a4ce00fb7737692d5acf16c1208b)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas