### PR TITLE
feat: add Camp Network Testnet V2 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -104,6 +104,7 @@
     "98865": "canonical",
     "175188": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "534352": "canonical",
     "560048": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -104,6 +104,7 @@
     "98865": "canonical",
     "175188": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "534352": "canonical",
     "560048": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -104,6 +104,7 @@
     "98865": "canonical",
     "175188": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "534352": "canonical",
     "560048": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -193,6 +193,7 @@
     "175188": "canonical",
     "205205": "canonical",
     "314159": "canonical",
+    "325000": "canonical",
     "381931": "canonical",
     "421614": "canonical",
     "444444": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 325000

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

blockexplorer: https://camp-network-testnet.blockscout.com

deploying "SimulateTxAccessor" (tx: 0xa9fc5709418ad58561c579b6c7c71fa3160d3c7050007518a16760cece6bb698)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x12428ab151e15274a97bffb9bdfeb5f7f5d4fd12f7fb8a9008fbcd78fecea9a6)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x033336eb02dffdc453c95c7490b4ba5516241f163477f113a526edc94148ea6e)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xa82a47b359618c648051a3b833130adaef4c5fb1cf17b7fec4711f2bf82a4621)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x7f95f1625726d0aab6d3f786288f52df79800216b554e9e0665e3f95c5a925f3)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x0370aa4d7b67f0274d98568ebeeeeda4f83327aba788415ca36cc3286a34316b)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0xbe59bf156c84efcdd80a761aead67cb3e8edb4220cfbbc56149404df6629faa5)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x88ecaa27676e274e5443eeb87dfa69ba384481d2e535a06ec1fd71e7ebd2f2cb)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x35c3c07412fceb6ec9b257866c871b099c5b56b1efa1403ee5ae9d116b24b56b)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x3a05fc134874fb5eda2b4087f11216e789f7d2c748bf37d744cf504f2bd9afa4)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0xb7729b68d544836869258574d4c55006bd954e803e5f1d134f0e7b8e12f6bc3c)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x3baa40448ece1498ed2a2c9d8143b395d1c9d7964ed4df695e17f95248d03cb1)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x1aaa1d356371b46a2c019be7a0e84ccb66502f451693009f53ee598b20ede42c)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas