### PR TITLE
feat: add Plume Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -107,6 +107,7 @@
     "84532": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "175188": "canonical",
     "314159": "canonical",
     "325000": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -107,6 +107,7 @@
     "84532": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "175188": "canonical",
     "314159": "canonical",
     "325000": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -107,6 +107,7 @@
     "84532": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "175188": "canonical",
     "314159": "canonical",
     "325000": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -191,6 +191,7 @@
     "90001": "canonical",
     "98864": "canonical",
     "98865": "canonical",
+    "98867": "canonical",
     "105105": "canonical",
     "111188": "canonical",
     "167000": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 98867

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

blockexplorer: https://testnet-explorer.plumenetwork.xyz

deploying "SimulateTxAccessor" (tx: 0x77222a0cb53df4bb5fc8a27de733df0a7fd4ca7495d4e9dcf1888f87000a0677)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
deploying "TokenCallbackHandler" (tx: 0x2f18855bd01638ed148ad6eee1f4d7aaaabb830a0f8a6af383d2a6059e9bfec0)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xcc31b6564889711d2eb7dde709a6d727b264caa06da34ef61a4d968a205c46d3)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x1d7d38efae2427707752909b8e5456a043bec4d792dc5a5e2de8cd5b6be28b52)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
deploying "SignMessageLib" (tx: 0x0048f7da3d24f6f510b94efe0ee73fc3b9f766725dc6b54dd2a3d9d1169d271d)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x100541f785a53ec944da36c53f882b80934e457251fb737712af0a7d777cae14)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
deploying "SafeL2" (tx: 0xba949595cf9b85736bfa4d0726b77f67a39bd3b68c51bab0d4d3d236f8f99c22)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0xb1a66fa5be2f54c7e1b4230f8fa9fc4970899cd079ea8c0c516345ccb695ba5c)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x0a86609242e6a7124b12a6613803a68ccad7f977802e535ea0a14172dd73fe5e)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas