### PR TITLE
feat: add 1.3.0 canonical contracts for Nibiru Mainnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -186,6 +186,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6880": "canonical",
+    "6900": "canonical",
     "7000": ["eip155", "canonical"],
     "7001": "eip155",
     "7070": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 6900

Relevant information:
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-6900.json
- https://nibiscan.io
