### PR TITLE
[New Chain]: Add COTI v2 Mainnet 1.4.1 contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -198,6 +198,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "7777777": "canonical",
     "11155111": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -198,6 +198,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "7777777": "canonical",
     "11155111": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -198,6 +198,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "7777777": "canonical",
     "11155111": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -255,6 +255,7 @@
     "839999": "canonical",
     "984122": "canonical",
     "1501869": "canonical",
+    "2632500": "canonical",
     "3441006": "canonical",
     "6038361": "canonical",
     "7225878": "canonical",


### PR DESCRIPTION
## Add new chain

COTI v2 Mainnet

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2632500

Relevant information:
- Block Explorer (Blockscout): https://mainnet.cotiscan.io/
