### PR TITLE
feat: add Gravity mainnet 1.3.0 addresses

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -143,6 +143,7 @@
     "1514": ["eip155", "canonical"],
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
+    "1625": "eip155",
     "1663": "eip155",
     "1729": "canonical",
     "1807": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1625

Relevant information:
https://explorer.gravity.xyz/
