### PR TITLE
Add Lens EVM Deployments

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -34,7 +34,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "252": "canonical",
     "255": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -34,7 +34,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "252": "canonical",
     "255": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -34,7 +34,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "252": "canonical",
     "255": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -45,7 +45,7 @@
     "196": "canonical",
     "204": "canonical",
     "228": "canonical",
-    "232": "zksync",
+    "232": ["zksync", "canonical"],
     "239": "canonical",
     "250": "canonical",
     "252": "canonical",


### PR DESCRIPTION
## Add new chain

- Chain_ID: 232

Relevant information:

Lens now has an EVM compatibility layer, so the Safe contracts with EVM bytecode can now be deployed to the canonical address :tada:.