### PR TITLE
[New chain]: Injective Testnet for v1.3.0

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -109,6 +109,7 @@
     "648": ["canonical", "eip155"],
     "686": "eip155",
     "690": ["eip155", "canonical"],
+    "698": "canonical",
     "747": "eip155",
     "787": "eip155",
     "919": ["canonical", "eip155"],


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1439

Relevant information:
Block Explorer: https://testnet.blockscout.injective.network/
