### PR TITLE
Network Review CI Improvements

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,7 +19,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: |
           npm ci
           bash bin/github-release.sh --verbose bump

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -18,7 +18,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: |
           npm ci
           bash bin/github-release.sh --verbose draft

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -16,7 +16,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: |
           npm ci
           bash bin/github-release.sh --verbose publish

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,15 +16,19 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
+    - name: Verify Review Script
+      run: |
+        git fetch https://github.com/safe-global/safe-deployments.git main:safe-global-main
+        if ! git diff --exit-code safe-global-main -- . ':!src/assets'; then
+          echo "ERROR: GitHub review script may not be up-to-date" 1>&2
+          exit 1
+        fi
+    - name: Install Dependencies
+      run: |
+        npm ci
     - name: Review PR
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        git fetch https://github.com/safe-global/safe-deployments.git main:safe-global-main
-        if ! git diff --exit-code safe-global-main -- bin/github-review.sh; then
-          echo "ERROR: GitHub review script is not up-to-date" 1>&2
-          exit 1
-        fi
-        npm ci
         bash bin/github-review.sh ${{ github.event.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: |
           npm ci
           npm test


### PR DESCRIPTION
Some small improvements to the review CI workflow:

* Bump the Node JS version to v22 - this is the current LTS version (this also applies to other workflows)
* Make sure the diff covers _all_ files that are not assets. This is important, as it avoids changes to the workflow file, but also the `scripts/review/verifyDeployment.js` file
* Split out the review verification and dependency installation to separate steps; for `npm ci` this has a nice security benefit that the `GH_TOKEN` is not available when installing packages. It also makes it easier to diagnose exactly what step fails in CI - (see #1142, where the CI output isn't clear if `npm ci` is exiting with code 22, or the review script is).
