### PR TITLE
Use DeFi Llama Chainlist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Add new chain
 
-> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [ethereum-lists/chains](https://github.com/ethereum-lists/chains). This entire paragraph should be deleted.
+> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's chainlist](https://chainlist.org/rpcs.json). This entire paragraph should be deleted.
 
 Please fill the following form:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Add new chain
 
-> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's chainlist](https://chainlist.org/rpcs.json). This entire paragraph should be deleted.
+> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.
 
 Please fill the following form:
 

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -69,7 +69,7 @@ if [[ $chain_exists != "true" ]]; then
 fi
 
 # Then get the RPC
-if ! rpc=$(echo "$chainlist" | jq -r ".[] | select(.chainId == $chainid) | .rpc[0].url"); then
+if ! rpc=$(echo "$chainlist" | jq --arg C "$chainid" -r '.[] | select((.chainId | tostring) == $C) | .rpc[0].url'); then
     echo "ERROR: Failed to parse RPC from chainlist response" 1>&2
     exit 1
 fi

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -56,7 +56,7 @@ fi
 
 # Parse the chainlist response
 if ! chainlist=$(echo "$chainlist_response" | jq -e '.'); then
-    echo "ERROR: Invalid JSON response from DefiLlama's chainlist" 1>&2
+    echo "ERROR: RPC not found for chain ID $chainid in DefiLlama's ChainList" 1>&2
     exit 1
 fi
 

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -47,10 +47,8 @@ if [[ -z $chainid ]]; then
 fi
 
 # Fetch RPC from DefiLlama's chainlist
-chainlist_response=$(curl -sfL 'https://chainlist.org/rpcs.json' || echo "CURL_ERROR:$?")
-if [[ $chainlist_response == CURL_ERROR:* ]]; then
-    error_code=${chainlist_response#CURL_ERROR:}
-    echo "ERROR: Failed to fetch chainlist from DefiLlama (curl error $error_code)" 1>&2
+if ! chainlist_response="$(curl -sfL 'https://chainlist.org/rpcs.json')"; then
+    echo "ERROR: Failed to fetch DeFiLlama ChainList" 1>&2
     exit 1
 fi
 

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -56,7 +56,7 @@ fi
 
 # Parse the chainlist response
 if ! chainlist=$(echo "$chainlist_response" | jq -e '.'); then
-    echo "ERROR: RPC not found for chain ID $chainid in DefiLlama's ChainList" 1>&2
+    echo "ERROR: DefiLlama's ChainList returned invalid JSON" 1>&2
     exit 1
 fi
 

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -45,12 +45,21 @@ if [[ -z $chainid ]]; then
     echo "ERROR: Chain ID not specified as per the PR Template" 1>&2
     exit 1
 fi
-chainInfo="https://raw.githubusercontent.com/ethereum-lists/chains/refs/heads/master/_data/chains/eip155-$chainid.json"
-rpc="$(curl -sfL "$chainInfo" | jq -r '.rpc[0]')"
-if [[ -z $rpc ]]; then
-    echo "ERROR: RPC not fetched correctly from the ethereum-lists" 1>&2
+
+# Fetch RPC from DefiLlama's chainlist
+chainlist="$(curl -sfL 'https://chainlist.org/rpcs.json')"
+if [[ -z $chainlist ]]; then
+    echo "ERROR: Failed to fetch chainlist from DefiLlama" 1>&2
     exit 1
 fi
+
+# Extract RPC for the specified chain ID using jq
+rpc="$(echo "$chainlist" | jq -r ".[] | select(.chainId == $chainid) | .rpc[0].url")"
+if [[ -z $rpc ]]; then
+    echo "ERROR: RPC not found for chain ID $chainid in DefiLlama's chainlist" 1>&2
+    exit 1
+fi
+
 version="$(gh pr diff $pr --name-only | sed -nE 's|^src/assets/v([0-9\.]*)/.*$|\1|p' | sort -u)"
 if [[ "$(echo "$version" | wc -w)" -ne 1 ]]; then
     echo "ERROR: Exactly one version must be added per PR" 1>&2
@@ -89,4 +98,3 @@ git restore --ignore-unmerged -- src/assets
 
 # NOTE/TODO
 # - We should still manually verify there is no removal of deployment types for a single chain.
-# - Getting the RPC from the Chainlist website instead of looking based on the provided RPC: https://github.com/safe-global/safe-deployments/pull/683#discussion_r1668555849

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -61,13 +61,21 @@ if ! chainlist=$(echo "$chainlist_response" | jq -e '.'); then
 fi
 
 # Extract RPC for the specified chain ID using jq
+# First check if the chain exists and has an RPC
+chain_exists=$(echo "$chainlist" | jq -r "map(select(.chainId == $chainid and (.rpc | length > 0))) | length > 0")
+if [[ $chain_exists != "true" ]]; then
+    echo "ERROR: RPC not found for chain ID $chainid in DefiLlama's chainlist" 1>&2
+    exit 1
+fi
+
+# Then get the RPC
 if ! rpc=$(echo "$chainlist" | jq -r ".[] | select(.chainId == $chainid) | .rpc[0].url"); then
     echo "ERROR: Failed to parse RPC from chainlist response" 1>&2
     exit 1
 fi
 
 if [[ -z $rpc || $rpc == "null" ]]; then
-    echo "ERROR: RPC not found for chain ID $chainid in DefiLlama's chainlist" 1>&2
+    echo "ERROR: No valid RPC URL found for chain ID $chainid in DefiLlama's chainlist" 1>&2
     exit 1
 fi
 

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -58,7 +58,7 @@ async function main() {
   }
   const chainExists = chainlist.some((chain) => chain.chainId === Number(options.chainId));
   if (!chainExists) {
-    throw new Error(`Chain ${options.chainId} is not registered on DefiLlama's chainlist`);
+    throw new Error(`Chain ${options.chainId} is not registered on DefiLlama's ChainList`);
   }
   debug(`chain ${options.chainId} exists on DefiLlama's chainlist`);
 

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -56,7 +56,7 @@ async function main() {
   if (!Array.isArray(chainlist)) {
     throw new Error('Invalid response format from DefiLlama chainlist');
   }
-  const chainExists = chainlist.some((chain) => chain.chainId === Number(options.chainId));
+  const chainExists = chainlist.some((chain) => `${chain.chainId}` === options.chainId);
   if (!chainExists) {
     throw new Error(`Chain ${options.chainId} is not registered on DefiLlama's ChainList`);
   }

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -60,7 +60,7 @@ async function main() {
   if (!chainExists) {
     throw new Error(`Chain ${options.chainId} is not registered on DefiLlama's ChainList`);
   }
-  debug(`chain ${options.chainId} exists on DefiLlama's chainlist`);
+  debug(`chain ${options.chainId} exists on DefiLlama's ChainList`);
 
   const provider = new ethers.JsonRpcProvider(options.rpc);
   const { chainId } = await provider.getNetwork();

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -49,7 +49,7 @@ async function main() {
   // Verify chain exists in DefiLlama's chainlist
   const response = await fetch('https://chainlist.org/rpcs.json');
   if (!response.ok) {
-    debug(response);
+    debug(`fetching chain list failed with HTTP status ${response.status}`);
     throw new Error(`Failed to fetch chainlist from DefiLlama`);
   }
   const chainlist = (await response.json()) as Array<{ chainId: number; rpcs: string[] }>;


### PR DESCRIPTION
We require that the chain appears on https://chainlist.org/, and previously, this meant that the chain was included in the ethereum-lists/chains repository. However, since that repository is no longer actively maintained, and since then DeFi Llama has added mechanisms for "additional chains" to their DeFiLlama/chainlist repository, which is the code behind https://chainlist.org/.

This PR changes our scripts to use the Chainlist.org API for checking if a network is listed or not (instead of the ethereum-lists/chains repository).
