### PR TITLE
feat: add 1.3.0 canonical contracts for Ethereal Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -336,6 +336,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
+    "657468": "canonical",
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 657468

Relevant information:
- https://github.com/safe-global/safe-singleton-factory/issues/1107
- https://github.com/DefiLlama/chainlist/pull/1771

```
deploying "SimulateTxAccessor" (tx: 0xd0be7624b3479630f9081adebe8ba101aac85ad294376adea58d0868528369ba)...: deployed at 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0xba22339043158ae78ab1b688d06eaa91fcb112ee475b734e647b6a000ba26d2f)...: deployed at 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0x803874a6ce0d157aa932c09c57a4e11067c2b7a3ca3efd8ffea5a40412828a7b)...: deployed at 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0xee4954c032ad45126d229dc195311096f84346fbde3099e74e3dc877b9dc05b8)...: deployed at 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4 with 1238441 gas
deploying "CreateCall" (tx: 0x8752a8936e287b881a3fc1bd66ab1b980e8e3cac69c0befa9e4704a59eadd71e)...: deployed at 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4 with 294790 gas
deploying "MultiSend" (tx: 0x97fc9918d67a356fe53c9ae7f95511f261136b7e224ad8e6d81146edef990aa6)...: deployed at 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761 with 190050 gas
deploying "MultiSendCallOnly" (tx: 0x3d1965e0b5ee84f29c74c372a53382809314c0d6707d0f7dacd0baf86c971f1d)...: deployed at 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D with 142150 gas
deploying "SignMessageLib" (tx: 0xcab6ff18fa44b7c949b99beb7828e3f196e380cff1615d1421f106d00d893fea)...: deployed at 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2 with 262417 gas
deploying "GnosisSafeL2" (tx: 0x9fe96bffdbe66f7b36812b338a313b93f7801ea35f62a45140a580db7e3bdc24)...: deployed at 0x3E5c63644E683549055b9Be8653de26E0B4CD36E with 5201733 gas
deploying "GnosisSafe" (tx: 0x9ad215d312442a44628d0097c9943eb7cb84a86f210b8b3491ea98d557383cd3)...: deployed at 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 with 5019271 gas
```
