### PR TITLE
feat: add 1.3.0 eip155 contracts for Ethereal Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -344,7 +344,7 @@
     "560048": ["eip155", "canonical"],
     "622277": "canonical",
     "656476": ["eip155", "canonical"],
-    "657468": "canonical",
+    "657468": ["canonical", "eip155"],
     "660279": "canonical",
     "668668": "canonical",
     "695569": ["eip155", "canonical"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 657468

Relevant information:
- https://github.com/safe-global/safe-singleton-factory/issues/1107
- https://github.com/DefiLlama/chainlist/pull/1771

```
deploying "SimulateTxAccessor" (tx: 0xf88c824657f6f6f83e0546c0bcc56cadefe963b97cc456b157dfce9fb3f9dba9)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0xc11513d668e841c81214174eb7874c8878720d8292969a64618c44d8be206390)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0x12a26e53ce4eb13e7869b05ac7626ebd12677e58480f5c99ff89be2789a60586)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0x005e5a71391dcc4208c3e31f0757c662699184ba6d41db37bc8a650d21ac9240)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238441 gas
deploying "CreateCall" (tx: 0x4ce4f072e7fb9d876062a15fb4a9b7654c312eb8449e2a544bb1f770868b23a7)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294790 gas
deploying "MultiSend" (tx: 0x44d62779d74c338343b157e7548ea969d562672a0f4701ebf15bba2717777397)...: deployed at 0x998739BFdAAdde7C933B942a68053933098f9EDa with 190050 gas
deploying "MultiSendCallOnly" (tx: 0xe68d8d26915c6226f36d715e00c989231eaa5dcb10b0244b750ac04c153ca2f0)...: deployed at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B with 142150 gas
deploying "SignMessageLib" (tx: 0xd677700392394c0b97a32f10cbbc0679568fdd071b032c6a659910c5fdd5d5b6)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262417 gas
deploying "GnosisSafeL2" (tx: 0x067e8e974ac1e306ba18a3c3a6e52be587257868adfd34de668b9e5bc0ee81ea)...: deployed at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA with 5201733 gas
deploying "GnosisSafe" (tx: 0xf1cd4771a4cada4e15426efd43826e35f69789fdd6eaebc5e9c4d55cacfb209e)...: deployed at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938 with 5019271 gas
```
