### PR TITLE
feat: add 1.5.0 contracts for Galactica Reticulum

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "9302": "canonical",
     "11155111": "canonical"
   },
   "abi": [


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 9302

Relevant information:
  - RPC_URL: https://evm-rpc-http-reticulum.galactica.com

  - safe-singleton-factory [issue](https://github.com/safe-global/safe-singleton-factory/issues/1102)

  - block explorer: https://explorer-reticulum.galactica.com/

<details>
    <summary>installation log of safe-global/safe-smart-account v1.4.1</summary>
    
    npm i --save-dev https://github.com/safe-global/safe-singleton-factory.git
    ...
    npm run deploy-all custom

    > @safe-global/safe-contracts@1.4.1 deploy-all
    > hardhat deploy-contracts --network custom

    You are using a version of Node.js that is not supported by Hardhat, and it may work incorrectly, or not work at all.

    Please, make sure you are using a supported version of Node.js.

    To learn more about which versions of Node.js are supported go to https://hardhat.org/nodejs-versions
    Downloading compiler 0.6.12
    contracts/interfaces/ViewStorageAccessible.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.

    @openzeppelin/contracts/token/ERC20/ERC20.sol:55:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor (string memory name_, string memory symbol_) public {
        ^ (Relevant source part starts here and spans across multiple lines).

    contracts/test/ERC20Token.sol:14:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor() public ERC20("TestToken", "TT") {
        ^ (Relevant source part starts here and spans across multiple lines).

    contracts/Safe.sol:352:5: Warning: Function state mutability can be restricted to pure
        function getChainId() public view returns (uint256) {
        ^ (Relevant source part starts here and spans across multiple lines).

    contracts/proxies/SafeProxyFactory.sol:117:5: Warning: Function state mutability can be restricted to pure
        function getChainId() public view returns (uint256) {
        ^ (Relevant source part starts here and spans across multiple lines).

    @gnosis.pm/mock-contract/contracts/MockContract.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.

    @gnosis.pm/mock-contract/contracts/MockContract.sol:78:1: Warning: This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function.
    contract MockContract is MockInterface {
    ^ (Relevant source part starts here and spans across multiple lines).
    @gnosis.pm/mock-contract/contracts/MockContract.sol:328:2: The payable fallback function is defined here.
    	fallback () payable external {
    ^ (Relevant source part starts here and spans across multiple lines).

    Compiled 39 Solidity files successfully
    An unexpected error occurred:

    Error: ERROR processing /srv/safe/safe-smart-account/src/deploy/deploy_accessors.ts:
    Error:
            Safe factory not found for network 9302. You can request a new deployment at https://github.com/safe-global/safe-singleton-factory.
            For more information, see https://github.com/safe-global/safe-contracts#replay-protection-eip-155

        at deterministicDeployment (/srv/safe/safe-smart-account/hardhat.config.ts:50:15)
        at DeploymentsManager.getDeterminisityDeploymentInfo (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/DeploymentsManager.ts:588:42)
        at processTicksAndRejections (node:internal/process/task_queues:105:5)
        at DeploymentsManager.getDeterministicDeploymentFactoryAddress (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/DeploymentsManager.ts:592:18)
        at fetchIfDifferent (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/helpers.ts:905:11)
        at _deployOne (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/helpers.ts:1002:24)
        at Object.deploy [as func] (/srv/safe/safe-smart-account/src/deploy/deploy_accessors.ts:9:5)
        at DeploymentsManager.executeDeployScripts (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/DeploymentsManager.ts:1222:22)
        at DeploymentsManager.runDeploy (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/DeploymentsManager.ts:1055:5)
        at SimpleTaskDefinition.action (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/index.ts:438:5)
        at DeploymentsManager.executeDeployScripts (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/DeploymentsManager.ts:1225:19)
        at processTicksAndRejections (node:internal/process/task_queues:105:5)
        at DeploymentsManager.runDeploy (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/DeploymentsManager.ts:1055:5)
        at SimpleTaskDefinition.action (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/index.ts:438:5)
        at Environment._runTaskDefinition (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:308:14)
        at Environment.run (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:156:14)
        at SimpleTaskDefinition.action (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/index.ts:584:32)
        at Environment._runTaskDefinition (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:308:14)
        at Environment.run (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:156:14)
        at SimpleTaskDefinition.action (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/index.ts:669:5)
</details>

<details>
    <summary>installation log of safe-global/safe-smart-account v1.5.0</summary>
    
    git checkout v1.5.0 && rm -rf node_modules
    npm i --save-dev https://github.com/safe-global/safe-singleton-factory.git
    ...
    npm run deploy-all custom

    > @safe-global/safe-smart-account@1.5.0 deploy-all
    > hardhat deploy-contracts --network custom

    Downloading compiler 0.7.6
    @openzeppelin/contracts/introspection/ERC165.sol:24:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor () internal {
        ^ (Relevant source part starts here and spans across multiple lines).

    @openzeppelin/contracts/proxy/UpgradeableProxy.sol:24:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor(address _logic, bytes memory _data) public payable {
        ^ (Relevant source part starts here and spans across multiple lines).

    @openzeppelin/contracts/token/ERC1155/ERC1155.sol:55:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor (string memory uri_) public {
        ^ (Relevant source part starts here and spans across multiple lines).

    @openzeppelin/contracts/token/ERC20/ERC20.sol:55:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor (string memory name_, string memory symbol_) public {
        ^ (Relevant source part starts here and spans across multiple lines).

    @openzeppelin/contracts/token/ERC721/ERC721.sol:93:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
        constructor (string memory name_, string memory symbol_) public {
        ^ (Relevant source part starts here and spans across multiple lines).

    contracts/libraries/SafeToL2Setup.sol:74:5: Warning: Function state mutability can be restricted to pure
        function chainId() private view returns (uint256 result) {
        ^ (Relevant source part starts here and spans across multiple lines).

    contracts/proxies/SafeProxyFactory.sol:137:5: Warning: Function state mutability can be restricted to pure
        function getChainId() public view returns (uint256) {
        ^ (Relevant source part starts here and spans across multiple lines).

    Generating typings for: 103 artifacts in dir: typechain-types for target: ethers-v6
    Successfully generated 240 typings!
    Compiled 88 Solidity files successfully (evm target: istanbul).
    deploying "SimulateTxAccessor" (tx: 0x6c9dbbb0e86dce2baf07be83eba1cc46a72f19b2ec764c5beacac1770af411db)...: deployed at 0x07EfA797c55B5DdE3698d876b277aBb6B893654C with 237931 gas
    deploying "SafeProxyFactory" (tx: 0x7bc8b7adebaa1daf7d0853d66ec3b21dbd09ddbd292f3c9d675ec6326aa3b7f6)...: deployed at 0x14F2982D601c9458F93bd70B218933A6f8165e7b with 770712 gas
    deploying "TokenCallbackHandler" (tx: 0x9aaf235748de4c68759df9237fd7d875914b4ba6e77a95564cd4f8a033ca6b34)...: deployed at 0x54e86d004d71a8D2112ec75FaCE57D730b0433F3 with 585229 gas
    deploying "CompatibilityFallbackHandler" (tx: 0x699f0a5b880cb87ddd8977191a74ecc5d4c3a52bcc46b8f265ea8be53d158eee)...: deployed at 0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4 with 1411837 gas
    deploying "ExtensibleFallbackHandler" (tx: 0x28c1dbbbf5e11162a60c899191498f1794b4b16e846f9fa1072cf39ccd24e623)...: deployed at 0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3 with 2566595 gas
    deploying "CreateCall" (tx: 0xdc26cd1f9a94a349be2b4a3aa2858a2ff411c2a03dd5f9b16e3f035a237a0fc2)...: deployed at 0x2Ef5ECfbea521449E4De05EDB1ce63B75eDA90B4 with 290470 gas
    deploying "MultiSend" (tx: 0xd35e04b7afa52c4de3642f75e746a84f65a7fd9e2a848da5ff15db20ba167e6f)...: deployed at 0x218543288004CD07832472D464648173c77D7eB7 with 192464 gas
    deploying "MultiSendCallOnly" (tx: 0x4045957073ab419e2f0f0c9ba6359ebb44522ef12ead4aba181135d05769411d)...: deployed at 0xA83c336B20401Af773B6219BA5027174338D1836 with 144558 gas
    deploying "SignMessageLib" (tx: 0x67edc659bbf289dd718cf6c8ea78f14ac1842856ba1d5eccceabea24ec6b8fa5)...: deployed at 0x4FfeF8222648872B3dE295Ba1e49110E61f5b5aa with 262417 gas
    deploying "SafeToL2Setup" (tx: 0xd7f43e4e567df56f5e5eb3ea047351e6a3306bc0163aad85b4df6e84c7a0ce01)...: deployed at 0x900C7589200010D6C6eCaaE5B06EBe653bc2D82a with 230851 gas
    deploying "Safe" (tx: 0xb434d9b4e70cfe61b6d9a5d32eb7b1c73c1634316bde97bcafdc8ae08ec3211c)...: deployed at 0xFf51A5898e281Db6DfC7855790607438dF2ca44b with 4702401 gas
    deploying "SafeL2" (tx: 0x48abd0d5bc2f9f23af007a842e0060fde83ce8a5ca9044d9d1fbddf249fc7fcd)...: deployed at 0xEdd160fEBBD92E350D4D398fb636302fccd67C7e with 4871409 gas
    deploying "SafeMigration" (tx: 0x7e352508dabe2ab73c1a67ea6ca21abcc131fa5ee793e1f1cad87d5d1bc27e65)...: deployed at 0x6439e7ABD8Bb915A5263094784C5CF561c4172AC with 512882 gas
    Verification status for SimulateTxAccessor: SUCCESS
    Verification status for SafeProxyFactory: SUCCESS
    Verification status for TokenCallbackHandler: SUCCESS
    Verification status for CompatibilityFallbackHandler: SUCCESS
    Verification status for ExtensibleFallbackHandler: SUCCESS
    Verification status for CreateCall: SUCCESS
    Verification status for MultiSend: SUCCESS
    Verification status for MultiSendCallOnly: SUCCESS
    Verification status for SignMessageLib: SUCCESS
    Verification status for SafeToL2Setup: SUCCESS
    Verification status for Safe: SUCCESS
    Verification status for SafeL2: SUCCESS
    Verification status for SafeMigration: SUCCESS
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying SimulateTxAccessor (0x07EfA797c55B5DdE3698d876b277aBb6B893654C on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying SafeProxyFactory (0x14F2982D601c9458F93bd70B218933A6f8165e7b on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying TokenCallbackHandler (0x54e86d004d71a8D2112ec75FaCE57D730b0433F3 on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying CompatibilityFallbackHandler (0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4 on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying ExtensibleFallbackHandler (0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3 on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying CreateCall (0x2Ef5ECfbea521449E4De05EDB1ce63B75eDA90B4 on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying MultiSend (0x218543288004CD07832472D464648173c77D7eB7 on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying MultiSendCallOnly (0xA83c336B20401Af773B6219BA5027174338D1836 on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying SignMessageLib (0x4FfeF8222648872B3dE295Ba1e49110E61f5b5aa on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying SafeToL2Setup (0x900C7589200010D6C6eCaaE5B06EBe653bc2D82a on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying Safe (0xFf51A5898e281Db6DfC7855790607438dF2ca44b on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying SafeL2 (0xEdd160fEBBD92E350D4D398fb636302fccd67C7e on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    {"error":"Invalid chainIds: 9302","message":"Invalid chainIds: 9302"}
    verifying SafeMigration (0x6439e7ABD8Bb915A5263094784C5CF561c4172AC on chain 9302) ...
    {"error":"Chain 9302 not supported for verification!","message":"Chain 9302 not supported for verification!"}
    An unexpected error occurred:

    Error: No Etherscan API KEY provided. Set it through command line option, in hardhat.config.ts, or by setting the "ETHERSCAN_API_KEY" env variable
        at SimpleTaskDefinition.action (/srv/safe/safe-smart-account/node_modules/hardhat-deploy/src/index.ts:867:13)
        at Environment._runTaskDefinition (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:351:35)
        at Environment.run (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:184:25)
        at Proxy.<anonymous> (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:310:29)
        at SimpleTaskDefinition.action (/srv/safe/safe-smart-account/src/tasks/deploy_contracts.ts:7:15)
        at processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async Environment._runTaskDefinition (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:351:14)
        at async Environment.run (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/core/runtime-environment.ts:184:14)
        at async main (/srv/safe/safe-smart-account/node_modules/hardhat/src/internal/cli/cli.ts:325:7)
</details>
