### PR TITLE
feat: add Abstract Mainnet 1.3.0 (eip155) contracts

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -178,7 +178,7 @@
     "2358": "eip155",
     "2390": "eip155",
     "2391": ["eip155", "canonical"],
-    "2741": ["zksync", "canonical"],
+    "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
     "3338": ["canonical", "eip155"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2741

Relevant information:
Abstract is zk Stack based chain with EVM contracts deployed (like zksync)
