### PR TITLE
Fix Asset Ordering Test

### DIFF
--- a/src/__tests__/assets.test.ts
+++ b/src/__tests__/assets.test.ts
@@ -37,8 +37,11 @@ describe('assets/', () => {
               // always order fields with numeric keys.
               const json = await readAsset(version, file);
               const networkAddresses = json.replace(/^[\s\S]*"networkAddresses" *: *\{([^}]*)\}[\s\S]*$/, '$1').trim();
-              const keys = networkAddresses.split(',').map((pair) => {
-                const [key] = pair.split(':');
+              const keys = networkAddresses.split('\n').map((pair) => {
+                const [key, ...rest] = pair.split(':');
+                if (rest.length !== 1) {
+                  throw new Error('more than one key per line');
+                }
                 return parseInt(key.trim().replace(/^"(.*)"$/, '$1'));
               });
               const sorted = [...keys].sort((a, b) => a - b);


### PR DESCRIPTION
This PR fixes the asset ordering test. The splitting on `,` was causing the "canonical" and "eip155" to be parsed as keys, which was turning into `NaN` and causing sorting to be unstable leading to false negatives (i.e. test would pass despite keys not being ordered, for example see #1191 ).

The fix is to split on newlines, and check that only one object key value pair exists per line.