### PR TITLE
Added 1.4.1 canonical support

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -160,6 +160,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -160,6 +160,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -160,6 +160,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -200,6 +200,7 @@
     "18880": "canonical",
     "23294": "canonical",
     "23295": "canonical",
+    "28802": "canonical",
     "28882": "canonical",
     "32380": "canonical",
     "32769": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 28802

Relevant information:
[PR Singleton Factory](https://github.com/safe-global/safe-singleton-factory/pull/1173)
[PR Chainlist](https://github.com/DefiLlama/chainlist/pull/1896)
[PR Etherscan](https://github.com/ethereum-lists/chains/pull/7675)

I have tried such branches: release/v1.4.1, v1.4.1-2, v1.4.1-1. My addresses didn't change at all. I see CHANGELOG.md, but I have no idea why it was deployed to another address.
```

`> @safe-global/safe-contracts@1.4.1-3 deploy-all
> hardhat deploy-contracts --network custom     

Nothing to compile
No need to generate any newer typings.
reusing "SimulateTxAccessor" at 0xBe6BD378a99F9f67D09270e33580C2c8be456a20
reusing "SafeProxyFactory" at 0x7759ca2f14B0e6544e6F3a25330Fa34C1A79CBe8
reusing "TokenCallbackHandler" at 0xCb1764c55Cf6dbefAC7c0Cec00FCEAC39aa5c2ef
reusing "CompatibilityFallbackHandler" at 0x5b795bC69D292dd93961F2C9f1f15Deb4C7EFa8C
reusing "CreateCall" at 0x6204cA4282DCB6d59Ffd9DE7541298776680a13E
reusing "MultiSend" at 0x0e508e1795cE78892132d7399163924324090C1b
reusing "MultiSendCallOnly" at 0x2b845496846bD55BF60C2c63822d2e6df38a04B8
reusing "SignMessageLib" at 0x080BDF7e0A9816B1462E096750adBFA6563ee93A
reusing "SafeToL2Setup" at 0x0BaC5594D6F154D3621d166B9452F5d0B45b6513
reusing "Safe" at 0xFedc87F5f38142783f4db60f4eb1296F3ec7991e
reusing "SafeL2" at 0xb10738E34bFA5B29762c89AC212D03f185C33671
reusing "SafeToL2Migration" at 0x26592628a12D1004C9a788e3B1b916aDfE93F66e
reusing "SafeMigration" at 0xf15f955E07824931BBCe6A4Dd10C6C0a29FCf0E7`

```