### PR TITLE
Add CapX testnet (chain ID: 756) deployments for Safe v1.5.0

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "756": "canonical",
     "1995": "canonical",
     "5424": "canonical",
     "5887": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

---

## Summary
This PR adds CapX testnet (chain ID: 756) deployment addresses for all Safe v1.5.0 contracts.

### Network Details
- Network: CapX Testnet
- Chain_ID: 756
- RPC: https://capx-testnet-c1.rpc.caldera.xyz/http
- Explorer: https://capx-testnet-c1.explorer.caldera.xyz/

## Deployment Details
- **Safe Version**: 1.5.0
- **Deployment Type**: Canonical (deterministic deployment)

## Contracts Deployed
All deployed addresses match the canonical Safe v1.5.0 addresses:
- Safe: 0xFf51A5898e281Db6DfC7855790607438dF2ca44b
- SafeL2: 0xEdd160fEBBD92E350D4D398fb636302fccd67C7e
- SafeProxyFactory: 0x14F2982D601c9458F93bd70B218933A6f8165e7b
- MultiSend: 0x218543288004CD07832472D464648173c77D7eB7
- MultiSendCallOnly: 0xA83c336B20401Af773B6219BA5027174338D1836
- CreateCall: 0x2Ef5ECfbea521449E4De05EDB1ce63B75eDA90B4
- SignMessageLib: 0x4FfeF8222648872B3dE295Ba1e49110E61f5b5aa
- CompatibilityFallbackHandler: 0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4
- ExtensibleFallbackHandler: 0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3
- SimulateTxAccessor: 0x07EfA797c55B5DdE3698d876b277aBb6B893654C
- TokenCallbackHandler: 0x54e86d004d71a8D2112ec75FaCE57D730b0433F3
- SafeToL2Setup: 0x900C7589200010D6C6eCaaE5B06EBe653bc2D82a
- SafeMigration: 0x6439e7ABD8Bb915A5263094784C5CF561c4172AC


### Deployment Transactions
```
deploying "SimulateTxAccessor" (tx: 0x28b16f8b1b39d8bd4f2a94adec93b4672345bb13b777631c9685d63260fd9355)...: deployed at 0x07EfA797c55B5DdE3698d876b277aBb6B893654C with 239225 gas
deploying "SafeProxyFactory" (tx: 0x58d272db99ee75d5e918df810dd75c810da8d59f507646d6cec9bae2182481eb)...: deployed at 0x14F2982D601c9458F93bd70B218933A6f8165e7b with 773193 gas
deploying "TokenCallbackHandler" (tx: 0x6f1871b094e98b01707d6525750bf705913eb7cbb6e6dc2a40a877e364bdeebc)...: deployed at 0x54e86d004d71a8D2112ec75FaCE57D730b0433F3 with 587046 gas
deploying "CompatibilityFallbackHandler" (tx: 0x5bf1aca831bfc5139fa1e5c7285f33df9d4634f6a3ea90602980d6a0cc5d5577)...: deployed at 0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4 with 1415401 gas
deploying "ExtensibleFallbackHandler" (tx: 0xb4b556bff984b02dde559e9fc01bbc038809e16c45ae6244b6eeb584c557162b)...: deployed at 0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3 with 2572284 gas
deploying "CreateCall" (tx: 0xa0e0c962e83f181d7fcface28c3b3f3e2e06bd55cc3ef24c3df08575dc97c109)...: deployed at 0x2Ef5ECfbea521449E4De05EDB1ce63B75eDA90B4 with 291582 gas
deploying "MultiSend" (tx: 0x8fb46c5ad0abd594ff8552f4989711e07b07f0ccbc73de863e6f0bd7eb988748)...: deployed at 0x218543288004CD07832472D464648173c77D7eB7 with 193598 gas
deploying "MultiSendCallOnly" (tx: 0xb3e91e40522dbd6cfe9f3988d3d0ef208157c45569e16ecb5862d09d81a98bd2)...: deployed at 0xA83c336B20401Af773B6219BA5027174338D1836 with 145457 gas
deploying "SignMessageLib" (tx: 0x03577403697ee7ebd145b018aee2ad6f2b61a65e60fac6147543ef45700cda5c)...: deployed at 0x4FfeF8222648872B3dE295Ba1e49110E61f5b5aa with 263684 gas
deploying "SafeToL2Setup" (tx: 0x817c6755d47c6e36a728a8a76325ad838afd6f11bc14e338d8749ee05e679565)...: deployed at 0x900C7589200010D6C6eCaaE5B06EBe653bc2D82a with 231998 gas
deploying "Safe" (tx: 0x4050d2228e4ad700ab5ef291503e20ffd16d40cf644b460e6bb39e45f9408c70)...: deployed at 0xFf51A5898e281Db6DfC7855790607438dF2ca44b with 4712749 gas
deploying "SafeL2" (tx: 0x3878b2d361d7e9a8575a986686412f547ac2673dbde65b7a46faf22eb93270e6)...: deployed at 0xEdd160fEBBD92E350D4D398fb636302fccd67C7e with 4882124 gas
deploying "SafeMigration" (tx: 0x8e6ea6b4f724d96d50fbd5bf71446f04ed53e5f57e322c3fcc64caa2482d94e4)...: deployed at 0x6439e7ABD8Bb915A5263094784C5CF561c4172AC with 514754 gas
```


## Verification
- ✅ Addresses verified against canonical deployments
- ✅ All tests passing
- ✅ JSON linting passed
