### PR TITLE
feat: add 1.5.0 contracts for Galactica Mainnet

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -19,6 +19,7 @@
     "49088": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",


### PR DESCRIPTION
## Add a new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).

- Chain_ID: 613419

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).

 - RPC_URL: https://galactica-mainnet.g.alchemy.com/public

Relevant information:

  - safe-singleton-factory issue: https://github.com/safe-global/safe-singleton-factory/issues/1211
  - block explorer: https://explorer.galactica.com


<details>
     <summary>installation log of safe-global/safe-smart-account v1.5.0</summary>
    ```
     diff --git a/package-lock.json b/package-lock.json
    index ac586bf..e7eca76 100644
    --- a/package-lock.json
    +++ b/package-lock.json
    @@ -13,7 +13,7 @@
                     "@nomicfoundation/hardhat-toolbox": "^6.0.0",
                     "@openzeppelin/contracts": "^3.4.2",
                     "@safe-global/mock-contract": "^4.1.0",
    -                "@safe-global/safe-singleton-factory": "^1.0.44",
    +                "@safe-global/safe-singleton-factory": "github:safe-global/safe-singleton-factory#0442d7b98f3eb7702a9a03f6fbee85327815a9f9",
                     "@types/chai": "^4.3.20",
                     "@types/mocha": "^10.0.10",
                     "@types/node": "^24.0.3",
    @@ -2198,9 +2198,9 @@
                 "license": "MIT"
             },
             "node_modules/@safe-global/safe-singleton-factory": {
    -            "version": "1.0.44",
    -            "resolved": "https://registry.npmjs.org/@safe-global/safe-singleton-factory/-/safe-singleton-factory-1.0.44.tgz",
    -            "integrity": "sha512-eJB+8c9ndShfjFwnzCGyDsXbANWLoqjdSlLCU5LNb5FmmH1ZlNJxDQ0DHHHXqkwOrmskvNLomAf1lOY4uYeCgQ==",
    +            "version": "2.0.0",
    +            "resolved": "git+ssh://git@github.com/safe-global/safe-singleton-factory.git#0442d7b98f3eb7702a9a03f6fbee85327815a9f9",
    +            "integrity": "sha512-xAZakeAP5kP8Brric3oX+Lnmz6uog5U2r3dmLJ42tuiEfNDZP8na0FcZjvOy6WRbeGIxHXxUMgkaEq2zaRVd2w==",
                 "dev": true,
                 "license": "MIT"
             },
    diff --git a/package.json b/package.json
    index a95f0cc..fdbfaa7 100644
    --- a/package.json
    +++ b/package.json
    @@ -60,7 +60,7 @@
             "@nomicfoundation/hardhat-toolbox": "^6.0.0",
             "@openzeppelin/contracts": "^3.4.2",
             "@safe-global/mock-contract": "^4.1.0",
    -        "@safe-global/safe-singleton-factory": "^1.0.44",
    +        "@safe-global/safe-singleton-factory": "github:safe-global/safe-singleton-factory#0442d7b98f3eb7702a9a03f6fbee85327815a9f9",
             "@types/chai": "^4.3.20",
             "@types/mocha": "^10.0.10",
             "@types/node": "^24.0.3",
    
    ```
    ```
             safe@gala-main-safe:~/mainnet/safe-smart-account$ npm i
             npm warn skipping integrity check for git dependency ssh://git@github.com/safe-global/safe-singleton-factory.git
             npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
             npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
             npm warn deprecated lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
             npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
             npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
             npm warn deprecated glob@5.0.15: Glob versions prior to v9 are no longer supported
             npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
             npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
             npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
             npm warn deprecated glob@7.1.7: Glob versions prior to v9 are no longer supported

             > @safe-global/safe-smart-account@1.5.0 prepublish
             > rimraf build && npm run build && npm run build:ts


             > @safe-global/safe-smart-account@1.5.0 build
             > hardhat compile

             @openzeppelin/contracts/introspection/ERC165.sol:24:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
                 constructor () internal {
                 ^ (Relevant source part starts here and spans across multiple lines).

             @openzeppelin/contracts/proxy/UpgradeableProxy.sol:24:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
                 constructor(address _logic, bytes memory _data) public payable {
                 ^ (Relevant source part starts here and spans across multiple lines).

             @openzeppelin/contracts/token/ERC1155/ERC1155.sol:55:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
                 constructor (string memory uri_) public {
                 ^ (Relevant source part starts here and spans across multiple lines).

             @openzeppelin/contracts/token/ERC20/ERC20.sol:55:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
                 constructor (string memory name_, string memory symbol_) public {
                 ^ (Relevant source part starts here and spans across multiple lines).

             @openzeppelin/contracts/token/ERC721/ERC721.sol:93:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
                 constructor (string memory name_, string memory symbol_) public {
                 ^ (Relevant source part starts here and spans across multiple lines).

             contracts/libraries/SafeToL2Setup.sol:74:5: Warning: Function state mutability can be restricted to pure
                 function chainId() private view returns (uint256 result) {
                 ^ (Relevant source part starts here and spans across multiple lines).

             contracts/proxies/SafeProxyFactory.sol:137:5: Warning: Function state mutability can be restricted to pure
                 function getChainId() public view returns (uint256) {
                 ^ (Relevant source part starts here and spans across multiple lines).

             Generating typings for: 103 artifacts in dir: typechain-types for target: ethers-v6
             Successfully generated 240 typings!
             Compiled 88 Solidity files successfully (evm target: istanbul).

             > @safe-global/safe-smart-account@1.5.0 build:ts
             > rimraf dist && tsc -p tsconfig.prod.json


             > @safe-global/safe-smart-account@1.5.0 prepare
             > husky


             added 831 packages, and audited 832 packages in 59s

             211 packages are looking for funding
               run `npm fund` for details

             27 vulnerabilities (17 low, 7 high, 3 critical)

             To address issues that do not require attention, run:
               npm audit fix

             To address all issues possible (including breaking changes), run:
               npm audit fix --force

             Some issues need review, and may require choosing
             a different dependency.

             Run `npm audit` for details.
    safe@gala-main-safe:~/mainnet/safe-smart-account$ npm run deploy-all custom

             > @safe-global/safe-smart-account@1.5.0 deploy-all
             > hardhat deploy-contracts --network custom

             Nothing to compile
             No need to generate any newer typings.
    deploying "SimulateTxAccessor" (tx: 0xc173a9b3a6db945b8d36f2229708ec454ebd36d303133eed65caec4702b38939)...: deployed at 0x07EfA797c55B5DdE3698d876b277aBb6B893654C with 237931 gas
    deploying "SafeProxyFactory" (tx: 0x39c2fa75822a09843d6df9ff292811cbb1e62b354e6dd47191b438b9e42867ec)...: deployed at 0x14F2982D601c9458F93bd70B218933A6f8165e7b with 770712 gas
    deploying "TokenCallbackHandler" (tx: 0xfd1370c090b35f1461de025aa93aecd3e7bbb5ea3c9d22323a12e6ea94c92e67)...: deployed at 0x54e86d004d71a8D2112ec75FaCE57D730b0433F3 with 585229 gas
    deploying "CompatibilityFallbackHandler" (tx: 0x3967b5787b791a9b5fc6920bb3be9d645a98a4e9b4e17bfee86d807749ba9a44)...: deployed at 0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4 with 1411837 gas
    deploying "ExtensibleFallbackHandler" (tx: 0xf2611a630c9f74bb520a2fc3c4aa7adbf586f8f766a469278c13e9b834aa52cb)...: deployed at 0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3 with 2566595 gas
    deploying "CreateCall" (tx: 0xb329abf8909d485e605576d058875adcc2567f859d78cad9ab5328006b5ac7b4)...: deployed at 0x2Ef5ECfbea521449E4De05EDB1ce63B75eDA90B4 with 290470 gas
    deploying "MultiSend" (tx: 0x463839de38f7cb3c2e66c27283b75ce6cdbf4515bb59513d6dada6a60c2828b4)...: deployed at 0x218543288004CD07832472D464648173c77D7eB7 with 192464 gas
    deploying "MultiSendCallOnly" (tx: 0xae03ade4589631589a4d4665e2957ab933705e391305ae687de8ac0f4444ecf6)...: deployed at 0xA83c336B20401Af773B6219BA5027174338D1836 with 144558 gas
    deploying "SignMessageLib" (tx: 0xa181386afe4a348151faec458fb12590d833fc8302d1387f9ab362f0037d5331)...: deployed at 0x4FfeF8222648872B3dE295Ba1e49110E61f5b5aa with 262417 gas
    deploying "SafeToL2Setup" (tx: 0x3f149d0e5fe7bdb128bde92d1f39c61694c71f6ec4393c5557a596c363fb45d9)...: deployed at 0x900C7589200010D6C6eCaaE5B06EBe653bc2D82a with 230851 gas
    deploying "Safe" (tx: 0x9730e130f6c5a140aa33e6ed9d61116c5a34d84253a9c49b161198d4b74a1449)...: deployed at 0xFf51A5898e281Db6DfC7855790607438dF2ca44b with 4702401 gas
    deploying "SafeL2" (tx: 0xc6531a71833fcd99c1af5034bc447e6365f72e34ec40606f51ba9e60a80ae3d5)...: deployed at 0xEdd160fEBBD92E350D4D398fb636302fccd67C7e with 4871409 gas
    deploying "SafeMigration" (tx: 0xfac2ab40d6ada045570c6bffcf8aff75cb4c8e57ca1699192e119e8bafeb0b66)...: deployed at 0x6439e7ABD8Bb915A5263094784C5CF561c4172AC with 512882 gas
    ```
</details>
