### PR TITLE
feat: add AB Core Testnet  1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -178,6 +178,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -178,6 +178,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -178,6 +178,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -218,6 +218,7 @@
     "23294": "canonical",
     "23295": "canonical",
     "24101": "canonical",
+    "26888": "canonical",
     "28802": "canonical",
     "28882": "canonical",
     "31611": "canonical",


### PR DESCRIPTION
feat: add AB Core Testnet  1.4.1 version contracts

## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 26888

Relevant information:

Explorer: https://explorer.core.testnet.ab.org/
Network name: AB Core Testnet
