### PR TITLE
add HPP Mainnet v1.5.0 contracts

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -21,6 +21,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "613419": "canonical",
     "843843": "canonical",
     "1440000": "canonical",


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 190415

Relevant information:

RPC: https://mainnet.hpp.io/

explorer: https://explorer.hpp.io/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `190415` (HPP Mainnet) mapping to `canonical` deployments across all v1.5.0 contract artifacts.
> 
> - **Assets v1.5.0**:
>   - Map chain `190415` -> `canonical` in:
>     - `src/assets/v1.5.0/safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`, `safe_to_l2_setup.json`
>     - `compatibility_fallback_handler.json`, `extensible_fallback_handler.json`, `token_callback_handler.json`
>     - `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ef104bf4263d1270a0ad84775a321614590a8f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->