### PR TITLE
feat: add 1.4.1 migration contracts for Blast Testnet

### DIFF
--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -281,6 +281,7 @@
     "21000000": "canonical",
     "65100004": "canonical",
     "111557560": "canonical",
+    "168587773": "canonical",
     "245022934": "canonical",
     "253368190": "canonical",
     "531050104": "zksync",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -281,6 +281,7 @@
     "21000000": "canonical",
     "65100004": "canonical",
     "111557560": "canonical",
+    "168587773": "canonical",
     "245022934": "canonical",
     "253368190": "canonical",
     "531050104": "zksync",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -281,6 +281,7 @@
     "21000000": "canonical",
     "65100004": "canonical",
     "111557560": "canonical",
+    "168587773": "canonical",
     "245022934": "canonical",
     "253368190": "canonical",
     "531050104": "zksync",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 168587773

Relevant information:
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-168587773.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `168587773` as a canonical network across the three v1.4.1 migration asset files.
> 
> - **Assets (v1.4.1)**:
>   - **Network mappings**:
>     - Add `168587773` → `canonical` in:
>       - `src/assets/v1.4.1/safe_migration.json`
>       - `src/assets/v1.4.1/safe_to_l2_migration.json`
>       - `src/assets/v1.4.1/safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db6289b6ea8d2b85771b75e4cba4e8512e94ff62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->