### PR TITLE
feat: add Celo Sepolia Testnet 1.4.1 version contracts

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -273,6 +273,7 @@
     "5064014": "canonical",
     "6985385": "canonical",
     "7777777": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -273,6 +273,7 @@
     "5064014": "canonical",
     "6985385": "canonical",
     "7777777": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -273,6 +273,7 @@
     "5064014": "canonical",
     "6985385": "canonical",
     "7777777": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -331,6 +331,7 @@
     "7225878": "canonical",
     "7777777": "canonical",
     "9999999": "canonical",
+    "11142220": "canonical",
     "11155111": "canonical",
     "11155420": "canonical",
     "11155931": "canonical",


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 11142220

Relevant information:

deploying "SimulateTxAccessor" (tx: 0xbb4502fa4546fd2a293b2ebee39d934f858256542b30ba95c9fca0631e1fafc7)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
deploying "TokenCallbackHandler" (tx: 0xd2874ffa4349f3d78ee27fd0deee3cef1e54f5f5cbc7cc8a4a22437bf6195ad6)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xeacc025de33acc379b246bb96440c145bb020e098017251200ca97c265dc301e)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x1e0eeef352ecd0c37d6379ea066e77ddc6655ecaea923c561052ce081218fe2c)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
deploying "SignMessageLib" (tx: 0xc87b49ae9af16483bbcd6db487b65f91d1ce85502a535a28aa44fe5a291a82a6)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0xed431670c4546e32a12da8bbf192cac92dd57694526dd45ad344edc92a443730)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
deploying "SafeL2" (tx: 0xb6bb47b60f586d38109306ec5ff5a473d195fd873c58848307e37de96ffd1095)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x387375baeb37a7f0a4e96319cb401c5677688c5aa18c0b9084674c2ac0863c51)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0xf2ad6374549769f617526c73fe4225fb5dbec8a9ad9238f1830a0a134797f8cf)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `11142220` to `networkAddresses` (mapped to `canonical`) across v1.4.1 Safe contract manifests.
> 
> - **Assets v1.4.1**:
>   - Add `11142220` → `canonical` in `networkAddresses` for:
>     - Core: `safe.json`, `safe_l2.json`, `safe_proxy_factory.json`
>     - Libs/Utils: `compatibility_fallback_handler.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`
>     - Migrations: `safe_migration.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 282cbdb76ee29ad1a57f771303f245ed0c7c026c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->