### PR TITLE
feat: add 1.3.0 canonical contracts for Etherlink Shadownet Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -340,6 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
+    "127823": "canonical",
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 127823

Relevant information:

- [X] All deployed contracts were verified at [Etherlink Shadownet Explorer](https://shadownet.explorer.etherlink.com/)

  - CompatibilityFallbackHandler: [0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4](https://shadownet.explorer.etherlink.com/address/0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4#code)
  - CreateCall: [0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4](https://shadownet.explorer.etherlink.com/address/0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4#code)
  - DefaultCallbackHandler: [0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd](https://shadownet.explorer.etherlink.com/address/0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd)
  - GnosisSafe: [0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552](https://shadownet.explorer.etherlink.com/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code)
  - GnosisSafeL2: [0x3E5c63644E683549055b9Be8653de26E0B4CD36E](https://shadownet.explorer.etherlink.com/address/0x3E5c63644E683549055b9Be8653de26E0B4CD36E#code)
  - MultiSend: [0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761](https://shadownet.explorer.etherlink.com/address/0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761#code)
  - MultiSendCallOnly: [0x40A2aCCbd92BCA938b02010E17A5b8929b49130D](https://shadownet.explorer.etherlink.com/address/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D#code)
  - GnosisSafeProxyFactory: [0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2](https://shadownet.explorer.etherlink.com/address/0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2#code)
  - SignMessageLib: [0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2](https://shadownet.explorer.etherlink.com/address/0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2#code)
  - SimulateTxAccessor: [0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da](https://shadownet.explorer.etherlink.com/address/0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da#code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add chain ID `127823` (canonical) across all Safe v1.3.0 asset manifests.
> 
> - **Assets v1.3.0**:
>   - Mark chain `127823` as `canonical` in `networkAddresses` for:
>     - `compatibility_fallback_handler.json`
>     - `create_call.json`
>     - `gnosis_safe.json`
>     - `gnosis_safe_l2.json`
>     - `multi_send.json`
>     - `multi_send_call_only.json`
>     - `proxy_factory.json`
>     - `sign_message_lib.json`
>     - `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7961d748a86b7a6ff98628756d688155a24ad1e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->