### PR TITLE
feat: add 1.3.0 eip155 contracts for Etherlink Shadownet Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": "canonical",
+    "127823": ["eip155", "canonical"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -340,7 +340,7 @@
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",
-    "127823": ["eip155", "canonical"],
+    "127823": ["canonical", "eip155"],
     "128123": ["eip155", "canonical"],
     "167000": ["eip155", "canonical"],
     "167008": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 127823

Relevant information:

- [x] EIP-155 contracts were deployed to network:

```
deploying "SimulateTxAccessor" (tx: 0x55687c8156fd11cf8156c8379c662b61f2ac2c0469e8bf2b6b3cbe87ef84f08f)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 4769931 gas
deploying "GnosisSafeProxyFactory" (tx: 0x31068b1281160ac538a93a3da9dde0e681983f43116e0ef495efabd040515200)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 16819832 gas
deploying "DefaultCallbackHandler" (tx: 0x4d615274d3a06d022c93ad6ebfa573a8d7ea780669b40f7a6ef18c883f788a78)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 10474617 gas
deploying "CompatibilityFallbackHandler" (tx: 0xa7d1f042579ba895e2c25d733a8b4de1ac89c93374332ef13be279f946d4dd8d)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 24062441 gas
deploying "CreateCall" (tx: 0x403340aed36d3ce5d2dc05e9a62c2ebdc10feabfb0e47b58033e21c77e65c3a5)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 5626790 gas
deploying "MultiSend" (tx: 0x995daa6e9ca8362129fd4ed4480f65a782d635dce3c8c2a5acee8b2b7adde48e)...: deployed at 0x998739BFdAAdde7C933B942a68053933098f9EDa with 3834050 gas
deploying "MultiSendCallOnly" (tx: 0x8aa788e381176f75bb3337dcb9ad9129531f43f16147817a8f9334cf92d310a8)...: deployed at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B with 2638150 gas
deploying "SignMessageLib" (tx: 0x1dca4762a9bae0946eb548c0c24fbe798c3a86f25c9b952b0c10c680d80da234)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 4982417 gas
deploying "GnosisSafeL2" (tx: 0x45d999cbcf5571b0d807e4eab0c188ef884b71dd794e66845fe9904f87de9a31)...: deployed at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA with 101293733 gas
deploying "GnosisSafe" (tx: 0x7e8456fa8faa22dabe74b497f37e11af87924819bd840a1309a182320d12f2a0)...: deployed at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938 with 97743271 gas
```

- [X] All deployed contracts were verified at [Etherlink Shadownet Explorer](https://shadownet.explorer.etherlink.com/)

  - CompatibilityFallbackHandler: [0x017062a1dE2FE6b99BE3d9d37841FeD19F573804](https://shadownet.explorer.etherlink.com/address/0x017062a1dE2FE6b99BE3d9d37841FeD19F573804#code)
  - CreateCall: [0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d](https://shadownet.explorer.etherlink.com/address/0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d#code)
  - DefaultCallbackHandler: [0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3](https://shadownet.explorer.etherlink.com/address/0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3#code)
  - GnosisSafe: [0x69f4D1788e39c87893C980c06EdF4b7f686e2938](https://shadownet.explorer.etherlink.com/address/0x69f4D1788e39c87893C980c06EdF4b7f686e2938#code)
  - GnosisSafeL2: [0xfb1bffC9d739B8D520DaF37dF666da4C687191EA](https://shadownet.explorer.etherlink.com/address/0xfb1bffC9d739B8D520DaF37dF666da4C687191EA#code)
  - MultiSend: [0x998739BFdAAdde7C933B942a68053933098f9EDa](https://shadownet.explorer.etherlink.com/address/0x998739BFdAAdde7C933B942a68053933098f9EDa#code)
  - MultiSendCallOnly: [0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B](https://shadownet.explorer.etherlink.com/address/0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B#code)
  - GnosisSafeProxyFactory: [0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC](https://shadownet.explorer.etherlink.com/address/0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC#code)
  - SignMessageLib: [0x98FFBBF51bb33A056B08ddf711f289936AafF717](https://shadownet.explorer.etherlink.com/address/0x98FFBBF51bb33A056B08ddf711f289936AafF717#code)
  - SimulateTxAccessor: [0x727a77a074D1E6c4530e814F89E618a3298FC044](https://shadownet.explorer.etherlink.com/address/0x727a77a074D1E6c4530e814F89E618a3298FC044#code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `eip155` to chain `127823` in `networkAddresses` for all Safe v1.3.0 contracts.
> 
> - **Assets v1.3.0**:
>   - Update `networkAddresses["127823"]` to `["canonical", "eip155"]` in:
>     - `src/assets/v1.3.0/compatibility_fallback_handler.json`
>     - `src/assets/v1.3.0/create_call.json`
>     - `src/assets/v1.3.0/gnosis_safe.json`
>     - `src/assets/v1.3.0/gnosis_safe_l2.json`
>     - `src/assets/v1.3.0/multi_send.json`
>     - `src/assets/v1.3.0/multi_send_call_only.json`
>     - `src/assets/v1.3.0/proxy_factory.json`
>     - `src/assets/v1.3.0/sign_message_lib.json`
>     - `src/assets/v1.3.0/simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62266baad489ac94ed11c88565b248bf90c64ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->