### PR TITLE
feat: add 1.3.0 eip155 contracts for Pharos Atlantic Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": ["eip155", "canonical"],
+    "688689": ["canonical", "eip155"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -370,7 +370,7 @@
     "660279": "canonical",
     "668668": "canonical",
     "688688": "eip155",
-    "688689": "canonical",
+    "688689": ["eip155", "canonical"],
     "695569": ["eip155", "canonical"],
     "713715": ["eip155", "canonical"],
     "747474": ["eip155", "canonical"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 688689

Relevant information:

- [x] Canonical contracts were deployed to network:

  ```
  deploying "SimulateTxAccessor" (tx: 0x34ddc23fe31d008db7c6ed03d28fce5173256ced25a7743dc65e499ae9e41260)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237931 gas
  deploying "GnosisSafeProxyFactory" (tx: 0x5fe836ecc75208228423942835eb218ced08dd56ede5744744c3bdc644104006)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867832 gas
  deploying "DefaultCallbackHandler" (tx: 0xd4f33b5a489f4a85cda838c859fe3300f49c6fa77581b19e06cf107bf9c34c93)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542617 gas
  deploying "CompatibilityFallbackHandler" (tx: 0x48d89c86a40675b1c9971c20c4059bda5fbfd415a6ff1bf29fdbe6ee64fc1bc2)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238441 gas
  deploying "CreateCall" (tx: 0xb91a82c6b20424a9ccbc2ef235eb3bb50666233fe1347413ad6e5167f4c3a1ea)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294790 gas
  reusing "MultiSend" at 0x998739BFdAAdde7C933B942a68053933098f9EDa
  reusing "MultiSendCallOnly" at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B
  deploying "SignMessageLib" (tx: 0x57b1afa9b583e5f02e75bbe324fe67680ba233c23e3b64998a01e2b0cba7cd63)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262417 gas
  reusing "GnosisSafeL2" at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA
  reusing "GnosisSafe" at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938
  ```

- [X] All deployed contracts were verified at [Pharos Testnet Explorer](https://atlantic.pharosscan.xyz/)

  - CompatibilityFallbackHandler: [0x017062a1dE2FE6b99BE3d9d37841FeD19F573804](https://atlantic.pharosscan.xyz/address/0x017062a1dE2FE6b99BE3d9d37841FeD19F573804#contract)
  - CreateCall: [0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d](https://atlantic.pharosscan.xyz/address/0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d#contract)
  - DefaultCallbackHandler: [0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3](https://atlantic.pharosscan.xyz/address/0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3#contract)
  - GnosisSafe: [0x69f4D1788e39c87893C980c06EdF4b7f686e2938](https://atlantic.pharosscan.xyz/address/0x69f4D1788e39c87893C980c06EdF4b7f686e2938#contract)
  - GnosisSafeL2: [0xfb1bffC9d739B8D520DaF37dF666da4C687191EA](https://atlantic.pharosscan.xyz/address/0xfb1bffC9d739B8D520DaF37dF666da4C687191EA#contract)
  - MultiSend: [0x998739BFdAAdde7C933B942a68053933098f9EDa](https://atlantic.pharosscan.xyz/address/0x998739BFdAAdde7C933B942a68053933098f9EDa#contract)
  - MultiSendCallOnly: [0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B](https://atlantic.pharosscan.xyz/address/0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B#contract)
  - GnosisSafeProxyFactory: [0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC](https://atlantic.pharosscan.xyz/address/0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC#contract)
  - SignMessageLib: [0x98FFBBF51bb33A056B08ddf711f289936AafF717](https://atlantic.pharosscan.xyz/address/0x98FFBBF51bb33A056B08ddf711f289936AafF717#contract)
  - SimulateTxAccessor: [0x727a77a074D1E6c4530e814F89E618a3298FC044](https://atlantic.pharosscan.xyz/address/0x727a77a074D1E6c4530e814F89E618a3298FC044#contract)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds eip155 support for chain `688689` by updating `networkAddresses` from `"canonical"` to `["canonical", "eip155"]` across v1.3.0 asset JSONs.
> 
> - **Assets v1.3.0**:
>   - Update `networkAddresses` for chain `688689` to `["canonical", "eip155"]` (from `"canonical"`) in:
>     - `compatibility_fallback_handler.json`
>     - `create_call.json`
>     - `gnosis_safe.json`
>     - `gnosis_safe_l2.json`
>     - `multi_send.json`
>     - `multi_send_call_only.json`
>     - `proxy_factory.json`
>     - `sign_message_lib.json`
>     - `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbcc5815b4c70a90efe64162592018bc8bf33f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->