### PR TITLE
Add HPP Mainnet v1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -243,6 +243,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "210425": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -243,6 +243,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "210425": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -243,6 +243,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "210425": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -293,6 +293,7 @@
     "167009": "canonical",
     "175188": "canonical",
     "181228": "canonical",
+    "190415": "canonical",
     "200810": "canonical",
     "200901": "canonical",
     "205205": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 190415

Relevant information:

explorerUrl: https://explorer.hpp.io/

RPC: https://mainnet.hpp.io/


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `190415` as `canonical` in `networkAddresses` across all v1.4.1 Safe contract JSON assets.
> 
> - **Assets v1.4.1**
>   - **networkAddresses**: Add `"190415": "canonical"` to:
>     - `src/assets/v1.4.1/safe.json`, `safe_l2.json`, `safe_proxy_factory.json`
>     - `compatibility_fallback_handler.json`, `create_call.json`
>     - `multi_send.json`, `multi_send_call_only.json`
>     - `sign_message_lib.json`, `simulate_tx_accessor.json`
>     - `safe_migration.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d98b082ca670ab1e11d7d5a5dba9b30539827c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->