### PR TITLE
feat: add Injective Mainnet V1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -94,6 +94,7 @@
     "1663": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1868": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -94,6 +94,7 @@
     "1663": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1868": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -94,6 +94,7 @@
     "1663": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1868": "canonical",
     "1923": "canonical",
     "1924": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -112,6 +112,7 @@
     "1729": "canonical",
     "1740": "canonical",
     "1750": "canonical",
+    "1776": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1776

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `1776` as `canonical` across Safe v1.4.1 contract asset network mappings.
> 
> - **Assets v1.4.1**:
>   - Add network mapping `1776: "canonical"` to:
>     - `compatibility_fallback_handler.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf73d8710b83fddf88a7fd476c28739ec751fc11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->