### PR TITLE
Add MegaETH chain ID 4326 for Safe 1.4.1 canonical deployments

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -127,6 +127,7 @@
     "4157": "canonical",
     "4158": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4488": "canonical",
     "4661": "canonical",
     "4801": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -127,6 +127,7 @@
     "4157": "canonical",
     "4158": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4488": "canonical",
     "4661": "canonical",
     "4801": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -127,6 +127,7 @@
     "4157": "canonical",
     "4158": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4488": "canonical",
     "4661": "canonical",
     "4801": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -151,6 +151,7 @@
     "4158": "canonical",
     "4162": "canonical",
     "4202": "canonical",
+    "4326": "canonical",
     "4337": "canonical",
     "4488": "canonical",
     "4653": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4326

Relevant information:
Add any other relevant information like blockexplorer, any annotation...
