### PR TITLE
Add MegaETH chain ID 4326 for Safe 1.5.0 canonical deployments

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "756": "canonical",
     "1995": "canonical",
+    "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
     "9302": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4326

Relevant information:
Add any other relevant information like blockexplorer, any annotation...
