### PR TITLE
feat: add 1.3.0 contracts for Morph Hoodi Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -185,6 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
+    "2910": "eip155",
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2910

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0xfa0b24e819df6b8a5a1479ef9fd847cb6cca6ce0c4bae0936d4e307024db24e4)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0x024d2a9331b896ff74516d21cfc9465c3a949d05fa20e9cda2d3ddbdf885700b)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0xab7dd7094f37d5788d8447197f48b7d3ca33ecfeb085c9694e373266bb82d740)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0x3be0c595b5e23ab2b1cfcf9466ab86e7844f2c0d6c14bca7dff42a75ed5ad927)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238441 gas
deploying "CreateCall" (tx: 0x97f54d7078d8d64273bdac18c7a5acece0cba060dbc55e1472a2ece96b7677b5)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294790 gas
deploying "MultiSend" (tx: 0x55a1d6fd96d4bb35d7cbec090e534f5c8c98e18c601aed1998e50cff30e0f628)...: deployed at 0x998739BFdAAdde7C933B942a68053933098f9EDa with 190050 gas
deploying "MultiSendCallOnly" (tx: 0xcd8982cd967e0b47c538ef7f247e4aea16118f540788d5ab71b11e95d92cfcc5)...: deployed at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B with 142150 gas
deploying "SignMessageLib" (tx: 0x352e40d01910fc5e1cbcdb16427b62fabc9f3defc6dcbd00b84124f8b5d56287)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262417 gas
deploying "GnosisSafeL2" (tx: 0xae0f81ec014be7ef44c3bc746b3e0b0ca9c59c05467fd1dba88d3c90b56bb70e)...: deployed at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA with 5201733 gas
deploying "GnosisSafe" (tx: 0xef4821d840e8f453e7a25da3bd8b1d8bb28752e8b86540ee86acd19fa664d92e)...: deployed at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938 with 5019271 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID 2910 (eip155) to networkAddresses across all Safe v1.3.0 contract JSONs.
> 
> - **Assets v1.3.0**:
>   - Add `2910` → `eip155` in `networkAddresses` for:
>     - `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`
>     - `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`
>     - `sign_message_lib.json`, `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebe4a1d1b7583812ddd2f6ab51044fb41dcecbff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->