### PR TITLE
feat: add 1.4.1 contracts for Morph Hoodi Testnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -118,6 +118,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -118,6 +118,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -118,6 +118,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -138,6 +138,7 @@
     "2741": ["zksync", "canonical"],
     "2810": "canonical",
     "2818": "canonical",
+    "2910": "canonical",
     "3068": "canonical",
     "3338": "canonical",
     "3501": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2910

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0xd21932f91bed681df4f20a49013f83c78c4a3b3e7be3d4dca91b5051e3a512f8)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x4def7258d7705958d34a86ba3fa3f856c1468b3e83a5f8b52191291b2e011ea2)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x1c1028e44aae2ef0ded27d6930346b76249062e89e4e52df4389d4cc37252f14)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0x5c62de668ec16feae635d7297808331e0cd2e02392b93d224f399b79b35efb79)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x161a46f0e2f52dbbbb45234d8067eb04e54dac5b28f7f92de04317d74c371d68)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0xdf0ad81dfac25f3fce010ea165fa66e0ed2fdf67fe4e8550c838a9251b3d02d9)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0xdf527ed8ace2dd9d86630872a99e6257732f96ab84c69b8b60eb4a2d90c62d1c)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0xd91f4ed123c3f117839347ca960c658c2db513b709ab3659a37c7d0138131173)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0xc174cc89aea6995e85ee9848e05eb7479330248a0fb2ff5427caa3f5e4259c09)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x1ba4f3ddfe5fe6ca38e909fc4aa86722dbdc43633aa6290d44344ea984be206b)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x25cc2eb023999cc11b6dc2093bb1049ca650d384c726e1141c7a922c60ba311d)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x82663cf801426fc3aebcf8103c3e87b42d754d595515c8736bc94ca8ed410488)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x2c3a49b4e786270efa7a8cf82367b236c59324a989ab503ea8854581af696ac4)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `2910` as `canonical` in `networkAddresses` across v1.4.1 contract JSONs.
> 
> - **Assets v1.4.1**:
>   - Add `2910: "canonical"` to `networkAddresses` in:
>     - `src/assets/v1.4.1/safe.json`
>     - `src/assets/v1.4.1/safe_l2.json`
>     - `src/assets/v1.4.1/safe_proxy_factory.json`
>     - `src/assets/v1.4.1/compatibility_fallback_handler.json`
>     - `src/assets/v1.4.1/create_call.json`
>     - `src/assets/v1.4.1/multi_send.json`
>     - `src/assets/v1.4.1/multi_send_call_only.json`
>     - `src/assets/v1.4.1/sign_message_lib.json`
>     - `src/assets/v1.4.1/simulate_tx_accessor.json`
>     - `src/assets/v1.4.1/safe_migration.json`
>     - `src/assets/v1.4.1/safe_to_l2_migration.json`
>     - `src/assets/v1.4.1/safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d95237b97674957cb10466668d9c16ed47bb3efd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->