### PR TITLE
Add eip155 deployment type for chain ID 4326 in Safe 1.3.0

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -196,7 +196,7 @@
     "4157": "eip155",
     "4158": "eip155",
     "4202": "canonical",
-    "4326": "canonical",
+    "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
     "4653": "eip155",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4326

Relevant information:
Add any other relevant information like blockexplorer, any annotation...
