### PR TITLE
feat: add 1.3.0 canonical contracts for Morph Hoodi Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -185,7 +185,7 @@
     "2741": ["zksync", "canonical", "eip155"],
     "2810": ["eip155", "canonical"],
     "2818": ["canonical", "eip155"],
-    "2910": "eip155",
+    "2910": ["eip155", "canonical"],
     "3338": ["canonical", "eip155"],
     "3636": "eip155",
     "3637": ["canonical", "eip155"],


### PR DESCRIPTION
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2910

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0x6f201d635dd12c7b8ea354bb77454e3e5f611adf898e596edfc83855b84eb030)...: deployed at 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0xf5a0589c1715b96b03a14a8f18b85b51f9f0e34cbb52635c28f5cb13798203d9)...: deployed at 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0x85cac8289ec75aa294038a11926f2de780b78f967be1e03ed46e3af6c798c8bd)...: deployed at 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0x3b05674a48d70d019938de70c147d10950d37fc293d1c0fce9aac2141b40e43e)...: deployed at 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4 with 1238441 gas
deploying "CreateCall" (tx: 0x01258d6340f4d7b4580b0dbf31d38abcc766f6ff1fb1b9fe0584956124ec7c8a)...: deployed at 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4 with 294790 gas
deploying "MultiSend" (tx: 0xb79ea88e71c5bc05cefd2c505b7c440db7f4dc01e4aba913bb7dd6970d044f94)...: deployed at 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761 with 190050 gas
deploying "MultiSendCallOnly" (tx: 0x8240524fe43d30b07c3c394dcce3c843c264bdc49418886bc403cdefdd40241b)...: deployed at 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D with 142150 gas
deploying "SignMessageLib" (tx: 0xaea4ff7cc59eac1d0182242dfc14b794a989a4fa5b43c061369c1c09a87c2a17)...: deployed at 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2 with 262417 gas
deploying "GnosisSafeL2" (tx: 0x85f4e4ef312357d10ad1da1fd00dce0aae90425fca511d79f20b65f0605d1b4e)...: deployed at 0x3E5c63644E683549055b9Be8653de26E0B4CD36E with 5201733 gas
deploying "GnosisSafe" (tx: 0x4cdc5f1f7eaf874ff4557287e3c46325e29dc131843b46d7371db3b2d27db306)...: deployed at 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 with 5019271 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `canonical` support for chain `2910` alongside `eip155` across v1.3.0 Safe contract assets.
> 
> - **Assets v1.3.0**:
>   - Mark chain `2910` as [`eip155`, `canonical`] in:
>     - `src/assets/v1.3.0/compatibility_fallback_handler.json`
>     - `src/assets/v1.3.0/create_call.json`
>     - `src/assets/v1.3.0/gnosis_safe.json`
>     - `src/assets/v1.3.0/gnosis_safe_l2.json`
>     - `src/assets/v1.3.0/multi_send.json`
>     - `src/assets/v1.3.0/multi_send_call_only.json`
>     - `src/assets/v1.3.0/proxy_factory.json`
>     - `src/assets/v1.3.0/sign_message_lib.json`
>     - `src/assets/v1.3.0/simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25bb1824cbd4a77b022b40b4549e3964d35c1d11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->