### PR TITLE
feat: add Spicy Testnet 1.3.0 eip155, canonical

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -339,6 +339,7 @@
     "83291": "canonical",
     "84531": "eip155",
     "84532": ["eip155", "canonical"],
+    "88882": ["eip155", "canonical"],
     "97435": "canonical",
     "103454": "eip155",
     "111188": "canonical",


### PR DESCRIPTION
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 88882

Relevant information:
canonical
```
deploying "SimulateTxAccessor" (tx: 0x607fba938e4eaae8a5551a5ac6878f79c9e656fa914b9f2416caa7b2a11d9db6)...: deployed at 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da with 289949 gas
deploying "GnosisSafeProxyFactory" (tx: 0x91e5d0f0f9422e6f27270831ac46f539f177a0670b964d969802c56fa39f0b48)...: deployed at 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 with 919850 gas
deploying "DefaultCallbackHandler" (tx: 0x06cf90715ceb7937889290aa84e3aaf4168217ddc7244af739e8d0b4a9b7a67e)...: deployed at 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd with 594635 gas
deploying "CompatibilityFallbackHandler" (tx: 0x6a6e2f9454e5ea93a65059da2b4ebd97dae73433c0bd53143eb1a9d1ab6d4501)...: deployed at 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4 with 1290459 gas
deploying "CreateCall" (tx: 0xe432f25d47f1c30adccf7aabfa9a7aac74e2d9d5c15553d6e515158a30c6cf32)...: deployed at 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4 with 346808 gas
deploying "MultiSend" (tx: 0x6b74d97b19cf227b07a1b63df44e61d5e935b99d27592c5b8179fc0962352903)...: deployed at 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761 with 242068 gas
deploying "MultiSendCallOnly" (tx: 0xb78f1ae76ecb7318f7f0f89e135d21e06de57a357f294d939e35a2b7521442b7)...: deployed at 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D with 194168 gas
deploying "SignMessageLib" (tx: 0x4f8109226dcdedb1e2d7da93a057c54523c13bfc459b458178380bb49bc7d7d8)...: deployed at 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2 with 314435 gas
deploying "GnosisSafeL2" (tx: 0x89458c5ffb92fec578701709458f77a9e68d811abedcc2a001c0703644478dbf)...: deployed at 0x3E5c63644E683549055b9Be8653de26E0B4CD36E with 5253751 gas
deploying "GnosisSafe" (tx: 0x696407d09d113d7fa66dc5eb3e23bd0bbb19fac5686b43247a133f7317bd8542)...: deployed at 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 with 5071289 gas
```
eip155
```
reusing "SimulateTxAccessor" at 0x727a77a074D1E6c4530e814F89E618a3298FC044
reusing "GnosisSafeProxyFactory" at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC
reusing "DefaultCallbackHandler" at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3
reusing "CompatibilityFallbackHandler" at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804
reusing "CreateCall" at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d
reusing "MultiSend" at 0x998739BFdAAdde7C933B942a68053933098f9EDa
reusing "MultiSendCallOnly" at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B
reusing "SignMessageLib" at 0x98FFBBF51bb33A056B08ddf711f289936AafF717
reusing "GnosisSafeL2" at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA
reusing "GnosisSafe" at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `88882` network mapping as ["eip155", "canonical"] across v1.3.0 Safe contract assets.
> 
> - **Assets v1.3.0**:
>   - Add `88882`: ["eip155", "canonical"] to `networkAddresses` in:
>     - `src/assets/v1.3.0/compatibility_fallback_handler.json`
>     - `src/assets/v1.3.0/create_call.json`
>     - `src/assets/v1.3.0/gnosis_safe.json`
>     - `src/assets/v1.3.0/gnosis_safe_l2.json`
>     - `src/assets/v1.3.0/multi_send.json`
>     - `src/assets/v1.3.0/multi_send_call_only.json`
>     - `src/assets/v1.3.0/proxy_factory.json`
>     - `src/assets/v1.3.0/sign_message_lib.json`
>     - `src/assets/v1.3.0/simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bcea2d1a71003efa6dd079fae9da6c5732c8588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->