### PR TITLE
feat: add Spicy Testnet 1.4.1 canonical

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -235,6 +235,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "91342": "canonical",
     "98864": "canonical",
     "98865": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -235,6 +235,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "91342": "canonical",
     "98864": "canonical",
     "98865": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -235,6 +235,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "91342": "canonical",
     "98864": "canonical",
     "98865": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -283,6 +283,7 @@
     "84532": "canonical",
     "88811": "canonical",
     "88817": "canonical",
+    "88882": "canonical",
     "90001": "canonical",
     "91342": "canonical",
     "98864": "canonical",


### PR DESCRIPTION
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 88882

Relevant information:
```
reusing "SimulateTxAccessor" at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
reusing "TokenCallbackHandler" at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
reusing "CreateCall" at 0x9b35Af71d77eaf8d7e40252370304687390A1A52
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
reusing "SignMessageLib" at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9
reusing "SafeToL2Setup" at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
reusing "SafeToL2Migration" at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69
reusing "SafeMigration" at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID 88882 as a canonical network across v1.4.1 contract manifests.
> 
> - **Assets v1.4.1**
>   - Add `88882` → `canonical` in `networkAddresses` for:
>     - `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`
>     - `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
>     - `compatibility_fallback_handler.json`, `create_call.json`
>     - `multi_send.json`, `multi_send_call_only.json`
>     - `sign_message_lib.json`, `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a56fdee2eaa3eda271a6d547ca4ef1a3102350c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->