### PR TITLE
feat(ethereal-1.5.0): added ethereal mainnet 1.5.0

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -28,6 +28,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5064014": "canonical",
     "11155111": "canonical"
   },
   "abi": [


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 5064014

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds network mapping for chain ID `5064014` to all Safe v1.5.0 artifact JSONs.
> 
> - **Assets (v1.5.0)**:
>   - Add `"5064014": "canonical"` to `networkAddresses` in:
>     - `src/assets/v1.5.0/safe.json`, `safe_l2.json`, `safe_proxy_factory.json`, `safe_migration.json`, `safe_to_l2_setup.json`
>     - `create_call.json`, `multi_send.json`, `multi_send_call_only.json`
>     - `compatibility_fallback_handler.json`, `extensible_fallback_handler.json`, `simulate_tx_accessor.json`, `sign_message_lib.json`, `token_callback_handler.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c121447a7fb678a43528c087d79128b44db534. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->