### PR TITLE
Add Studio Chain to v1.3.0

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -199,6 +199,7 @@
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
     "4460": "canonical",
+    "4509": "canonical",
     "4653": "eip155",
     "4661": "canonical",
     "4689": "eip155",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4509

Relevant information:
- safe single factory issue: https://github.com/safe-fndn/safe-singleton-factory/issues/1261
- block explorer: https://studio-chain.explorer.caldera.xyz/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `4509` as `canonical` across v1.3.0 Safe contract asset `networkAddresses`.
> 
> - **Assets v1.3.0**:
>   - Add `4509: "canonical"` to `networkAddresses` in:
>     - `compatibility_fallback_handler.json`
>     - `create_call.json`
>     - `gnosis_safe.json`
>     - `gnosis_safe_l2.json`
>     - `multi_send.json`
>     - `multi_send_call_only.json`
>     - `proxy_factory.json`
>     - `sign_message_lib.json`
>     - `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 264a152c0164ccb825d6e434e575868ecdb4e6b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->