### PR TITLE
Add alphachain mainnet 1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -120,6 +120,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -120,6 +120,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -120,6 +120,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -140,6 +140,7 @@
     "2818": "canonical",
     "2910": "canonical",
     "3068": "canonical",
+    "3111": "canonical",
     "3338": "canonical",
     "3501": "canonical",
     "3636": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 3111

Relevant information:
Add any other relevant information like blockexplorer, any annotation...

```
Nothing to compile
No need to generate any newer typings.
reusing "SimulateTxAccessor" at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
reusing "TokenCallbackHandler" at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
reusing "CreateCall" at 0x9b35Af71d77eaf8d7e40252370304687390A1A52
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
reusing "MultiSendCallOnly" at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
reusing "SignMessageLib" at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9
reusing "SafeToL2Setup" at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54
reusing "Safe" at 0x41675C099F32341bf84BFc5382aF534df5C7461a
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
reusing "SafeToL2Migration" at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69
reusing "SafeMigration" at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6
Verification status for CompatibilityFallbackHandler: SUCCESS
Verification status for CreateCall: SUCCESS
Verification status for MultiSend: SUCCESS
Verification status for MultiSendCallOnly: SUCCESS
Verification status for Safe: SUCCESS
Verification status for SafeL2: SUCCESS
Verification status for SafeMigration: SUCCESS
Verification status for SafeProxyFactory: SUCCESS
Verification status for SafeToL2Migration: SUCCESS
Verification status for SafeToL2Setup: SUCCESS
Verification status for SignMessageLib: SUCCESS
Verification status for SimulateTxAccessor: SUCCESS
Verification status for TokenCallbackHandler: SUCCESS
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID 3111 as a canonical network across all Safe v1.4.1 contract artifacts.
> 
> - **Networks**:
>   - Map `chainId 3111` to `canonical` in v1.4.1 artifacts: `safe.json`, `safe_l2.json`, `safe_proxy_factory.json`, `safe_migration.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`, `compatibility_fallback_handler.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc0d41936224f2f16789d7236978a8647cebd624. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->