### PR TITLE
feat: add Moca testnet 1.3.0 eip155

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": ["eip155", "canonical"],
+    "222888": ["canonical", "eip155"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -355,7 +355,7 @@
     "200202": "canonical",
     "200810": "canonical",
     "200901": "canonical",
-    "222888": "canonical",
+    "222888": ["eip155", "canonical"],
     "314159": "eip155",
     "328527": "canonical",
     "333999": "canonical",


### PR DESCRIPTION
## Add new chain
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 222888

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0xe4ff28ba963eda5c907fb1bf5788b0db3edfed3dcf6018e516df4a970fc6cfe9)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237871 gas
deploying "GnosisSafeProxyFactory" (tx: 0x9f34280ccc4f73d9f1da10b7f5146475e1e02da4212e9b73b8378655bc17e9af)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867594 gas
deploying "DefaultCallbackHandler" (tx: 0x1009b9d90e72407232e52a17d789fed731fcc71fbbd60f32608cc9c8f9108b8e)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542473 gas
deploying "CompatibilityFallbackHandler" (tx: 0xda5074bdabeca1b2b7431a516a92c7430173420aaa58a8c5b210f8520fa7aeef)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238095 gas
deploying "CreateCall" (tx: 0xd7fa5771ef83b6dd188c72b9634495b5f7265cdf80e8d2a1ff29e284e22ad096)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294718 gas
deploying "MultiSend" (tx: 0x261ba2e894102b5911decdd309c2f3d084ac4932c6ebf300c396d9a6b5bc55b9)...: deployed at 0x998739BFdAAdde7C933B942a68053933098f9EDa with 190004 gas
deploying "MultiSendCallOnly" (tx: 0x1b433e19d6cd3580c2590b7106b2fcbcedc44e8cf99ad2e8669672c32b41eb58)...: deployed at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B with 142122 gas
deploying "SignMessageLib" (tx: 0xd222caaaeade19624c0506a38e753e63b057c80b8f5e689beb570e6bce3a7062)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262353 gas
deploying "GnosisSafeL2" (tx: 0x1e7b05a5273cb1664fb7722e0690cab287e985f348f6d7ca4da25827826c61cf)...: deployed at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA with 5200241 gas
deploying "GnosisSafe" (tx: 0x3d4757c130030121a793117fb60e184ce5cb989c4e8381c359a439121e861461)...: deployed at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938 with 5017833 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `eip155` to chain `222888` network mappings in multiple v1.3.0 contract metadata files.
> 
> - **Assets v1.3.0**:
>   - Update `networkAddresses` for chain `222888` to include `"eip155"` (now `["canonical", "eip155"]`) in:
>     - `compatibility_fallback_handler.json`
>     - `create_call.json`
>     - `gnosis_safe.json`
>     - `gnosis_safe_l2.json`
>     - `multi_send.json`
>     - `multi_send_call_only.json`
>     - `proxy_factory.json`
>     - `sign_message_lib.json`
>     - `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b2f936b86153f4769417b0bbd0863eb91afdf7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->