### PR TITLE
feat: add Moca testnet 1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -256,6 +256,7 @@
     "200810": "canonical",
     "200901": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -256,6 +256,7 @@
     "200810": "canonical",
     "200901": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -256,6 +256,7 @@
     "200810": "canonical",
     "200901": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -307,6 +307,7 @@
     "200901": "canonical",
     "205205": "canonical",
     "210425": "canonical",
+    "222888": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "381931": "canonical",


### PR DESCRIPTION
## Add new chain
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 222888

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0x1576ad7eacc0227ffd7269e338c7e547d761d32a4037004d496585b92bcb0962)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
deploying "TokenCallbackHandler" (tx: 0x0643eab6faca6b6bcff728c5249935f60191399d83c15dfdec434337950df3d3)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
deploying "CreateCall" (tx: 0xf43832f0f49c13b11cb11e9e026b080d86f29180470d81836c31dd327c060281)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
deploying "MultiSendCallOnly" (tx: 0x6eb08d28d9a7711282d2d349d86c4fa0def65f10e7c90bc161aecaefe8e4b161)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0xd35991275dd7d6256f78d5338aa4a602233e391b68f3200817c51d12265011b0)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0x97792531b1bca5aab00ffefdefb1bd72021c2b5cfde4eb93a73e0cf2f7a62b83)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0x55f98e5b99b9d6644edfa3b5787745b2de27b7f153cf0a83bfce5874a410cdb9)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
deploying "SafeToL2Migration" (tx: 0xba6a0b0bcc15d0ae9b510f722fa2b9011ea7e11acf92972601f42cfb3ffea8fb)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0x52164dcb847ec5a53909984eadbfebf5c63c5b264e3a3ab292414df14c227a80)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds network ID 222888 mapped to `canonical` across all v1.4.1 contract asset files.
> 
> - **Assets v1.4.1**:
>   - Add chain ID `222888` → `canonical` in `networkAddresses` for:
>     - `compatibility_fallback_handler.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`
>     - `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`
>     - `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
>     - `sign_message_lib.json`, `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4562e1511064accc7ea5bf34d369c9463c34622f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->