### PR TITLE
feat: add Warden Protocol mainnet v1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -159,6 +159,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -159,6 +159,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -159,6 +159,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -193,6 +193,7 @@
     "8408": "canonical",
     "8453": "canonical",
     "8700": "canonical",
+    "8765": "canonical",
     "8801": "canonical",
     "8844": "canonical",
     "9001": "canonical",


### PR DESCRIPTION
## Add new chain

This PR adds the Warden Protocol blockchain, we have deployed the contracts version v1.4.1 at the canonical addresses.

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 8765

Relevant information:

- Block explorer: https://explorer.wardenprotocol.org
- This is a Cosmos SDK + cosmos/evm (v0.5) chain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID 8765 mapping to canonical deployments across v1.4.1 Safe contract assets.
> 
> - **Assets v1.4.1**:
>   - Map chain `8765` to `canonical` in `networkAddresses` for:
>     - `safe.json`, `safe_l2.json`, `safe_proxy_factory.json`
>     - `create_call.json`, `multi_send.json`, `multi_send_call_only.json`
>     - `compatibility_fallback_handler.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`
>     - `safe_migration.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41094bc79293f52e1ff4f59550a461d63e36fc87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->