### PR TITLE
feat: add 1.3.0 canonical for Sophon OS Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -408,7 +408,7 @@
     "333000333": "canonical",
     "476462898": "canonical",
     "531050104": "zksync",
-    "531050204": "eip155",
+    "531050204": ["eip155", "canonical"],
     "666666666": ["canonical", "eip155"],
     "888888888": "canonical",
     "999999999": ["canonical", "eip155"],


### PR DESCRIPTION
## Add new chain
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 531050204

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0xcb3b693363bc2268cd776fc28144e6d68062281d9558916ea8aadd3d8b5ab038)...: deployed at 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0x9cf782f6a09bb14fe52c97fcefa8fa76d1be60bc38a4056701f6275d687f49b7)...: deployed at 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0x9d673df5da1dd96b7232c63ef97eec847b5ed68050e4d0fe0559de2416c77275)...: deployed at 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0xedd5d5818c968b2dc54ea1f722db835702656199ef33cb368ddbe909d7c8bc85)...: deployed at 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4 with 1238441 gas
deploying "CreateCall" (tx: 0x8040496e4d176a6dc5ef0e4b24d36ca9a7c7f2353564cff2ddafc00833199def)...: deployed at 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4 with 294790 gas
deploying "MultiSend" (tx: 0x3c7abbad7e633470222bddada5606ed4f463b60163906e4480afe44f3e2e0efc)...: deployed at 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761 with 190050 gas
reusing "MultiSendCallOnly" at 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D
deploying "SignMessageLib" (tx: 0x44087f03b9075d619ffe68dfdbd16305c8ca04409da75806d8335c31ac6f3395)...: deployed at 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2 with 262417 gas
deploying "GnosisSafeL2" (tx: 0x1f95be6db5a7de9770887c7cbbf20b369bd0c4c643ef353eaf9b6de0dae3066c)...: deployed at 0x3E5c63644E683549055b9Be8653de26E0B4CD36E with 5201733 gas
deploying "GnosisSafe" (tx: 0x6e1dbb3a6b71a60f2f252ebdc8389ae90afbe550bfc54025e5060d67141f3ef1)...: deployed at 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 with 5019271 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks chain `531050204` as both `eip155` and `canonical` across all Safe v1.3.0 asset manifests.
> 
> - **Assets v1.3.0**:
>   - Update `networkAddresses` for chain `"531050204"` to `["eip155", "canonical"]` in:
>     - `compatibility_fallback_handler.json`
>     - `create_call.json`
>     - `gnosis_safe.json`
>     - `gnosis_safe_l2.json`
>     - `multi_send.json`
>     - `multi_send_call_only.json`
>     - `proxy_factory.json`
>     - `sign_message_lib.json`
>     - `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e5fa5bd05a55e2e9c8a76e4d8fcdb77656868ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->