### PR TITLE
feat: add 1.4.1 contracts for Pruv Testnet (chainID 7336)

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -152,6 +152,7 @@
     "7001": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7897": "canonical",
     "8008": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -152,6 +152,7 @@
     "7001": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7897": "canonical",
     "8008": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -152,6 +152,7 @@
     "7001": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7897": "canonical",
     "8008": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -183,6 +183,7 @@
     "7171": "canonical",
     "7200": "canonical",
     "7208": "canonical",
+    "7336": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",


### PR DESCRIPTION
Add a new chain

- Chain_ID: 7336

- RPC_URL: https://rpc.testnet.pruv.network/

Relevant information:

- safe-singleton-factory issue: https://github.com/safe-fndn/safe-singleton-factory/pull/1301
- block explorer: https://explorer.testnet.pruv.network/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `7336` support by mapping it to `canonical` deployments across all v1.4.1 asset JSONs.
> 
> - **Assets v1.4.1**:
>   - Add network mapping `"7336": "canonical"` in:
>     - `compatibility_fallback_handler.json`
>     - `create_call.json`
>     - `multi_send.json`
>     - `multi_send_call_only.json`
>     - `safe.json`
>     - `safe_l2.json`
>     - `safe_migration.json`
>     - `safe_proxy_factory.json`
>     - `safe_to_l2_migration.json`
>     - `safe_to_l2_setup.json`
>     - `sign_message_lib.json`
>     - `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ba09088b72d03c43b510f47e044e32f04de3be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->