### PR TITLE
feat: add 1.4.1 contracts for Pruv Mainnet (chain 7337)

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -154,6 +154,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7897": "canonical",
     "8008": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -154,6 +154,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7897": "canonical",
     "8008": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -154,6 +154,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7897": "canonical",
     "8008": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -185,6 +185,7 @@
     "7200": "canonical",
     "7208": "canonical",
     "7336": "canonical",
+    "7337": "canonical",
     "7560": "canonical",
     "7771": "canonical",
     "7897": "canonical",


### PR DESCRIPTION
Add a new chain

- Chain_ID: 7337

- RPC_URL: https://rpc.pruv.network/

Relevant information:

- safe-singleton-factory issue: https://github.com/safe-fndn/safe-singleton-factory/pull/1300
- block explorer: https://explorer.pruv.network/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add chain `7337` as `canonical` in v1.4.1 contract network mappings across all core manifests.
> 
> - **Assets v1.4.1**:
>   - **Network address mappings**: Add `7337` mapped to `"canonical"` across core contract manifests:
>     - `safe.json`, `safe_l2.json`, `safe_proxy_factory.json`
>     - `multi_send.json`, `multi_send_call_only.json`
>     - `create_call.json`, `compatibility_fallback_handler.json`
>     - `sign_message_lib.json`, `simulate_tx_accessor.json`
>     - `safe_migration.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8b946c4a2e1cb969b3cfb8504c8044dbe0daf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->