### PR TITLE
Add v1.4.1 contract for PlatON Dev Testnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -295,6 +295,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "65100004": "canonical",
     "111557560": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -295,6 +295,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "65100004": "canonical",
     "111557560": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -295,6 +295,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "65100004": "canonical",
     "111557560": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -353,6 +353,7 @@
     "12227332": "canonical",
     "13374202": "canonical",
     "13863860": "canonical",
+    "20250407": "canonical",
     "21000000": "canonical",
     "52164803": "canonical",
     "65100004": "canonical",


### PR DESCRIPTION
## Add new chain

PlatON Dev Testnet

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).

- Chain_ID: 20250407

Provide RPC URL for the chain (should be able to query atleast 10 requests per minute for automatic PR check).

- RPC_URL:  https://devnet3openapi.platon.network/rpc

Relevant information:

- Block explorer:  https://devnet3scan.platon.network/


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID 20250407 (PlatON Dev Testnet) as `canonical` across all v1.4.1 contract artifact `networkAddresses` mappings.
> 
> - **Contracts v1.4.1**:
>   - Add chain ID `20250407` mapped to `canonical` in `networkAddresses` across all contract artifacts (`Safe`, `SafeL2`, `SafeProxyFactory`, `MultiSend`, `MultiSendCallOnly`, `CreateCall`, `SignMessageLib`, `CompatibilityFallbackHandler`, `SimulateTxAccessor`, `SafeMigration`, `SafeToL2Migration`, `SafeToL2Setup`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ed38eb7019d8379601cbb2017031277981fa936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->