### PR TITLE
Add CapX testnet (chain ID: 756) deployments for Safe v1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -62,6 +62,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -62,6 +62,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -62,6 +62,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -77,6 +77,7 @@
     "592": "canonical",
     "690": "canonical",
     "747": "canonical",
+    "756": "canonical",
     "841": "canonical",
     "842": "canonical",
     "870": "canonical",


### PR DESCRIPTION
## Summary
This PR adds CapX testnet (chain ID: 756) deployment addresses for all Safe v1.4.1 contracts.

### Network Details
- Network: CapX Testnet
- Chain_ID: 756
- RPC: https://capx-testnet-c1.rpc.caldera.xyz/http
- Explorer: https://capx-testnet-c1.explorer.caldera.xyz/

## Deployment Details
- **Safe Version**: 1.4.1
- **Deployment Type**: Canonical (deterministic deployment)
- **Files Changed**: 12

## Contracts Deployed
All deployed addresses match the canonical Safe v1.4.1 addresses:
- Safe: 0x41675C099F32341bf84BFc5382aF534df5C7461a
- SafeL2: 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
- SafeProxyFactory: 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
- MultiSend: 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
- MultiSendCallOnly: 0x9641d764fc13c8B624c04430C7356C1C7C8102e2
- CreateCall: 0x9b35Af71d77eaf8d7e40252370304687390A1A52
- SignMessageLib: 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9
- CompatibilityFallbackHandler: 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
- SimulateTxAccessor: 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199
- SafeMigration: 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6
- SafeToL2Migration: 0xfF83F6335d8930cBad1c0D439A841f01888D9f69
- SafeToL2Setup: 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54

## Verification
- ✅ Addresses verified against canonical deployments
- ✅ All tests passing
- ✅ JSON linting passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chain ID `756` (CapX testnet) as `canonical` to all Safe v1.4.1 asset manifests.
> 
> - **Assets v1.4.1**:
>   - Add `networkAddresses` entry `"756": "canonical"` to:
>     - `safe.json`, `safe_l2.json`, `safe_proxy_factory.json`
>     - `multi_send.json`, `multi_send_call_only.json`
>     - `create_call.json`, `sign_message_lib.json`, `compatibility_fallback_handler.json`, `simulate_tx_accessor.json`
>     - `safe_migration.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 643e5a0f6ddb58b7ca8ad12efadaa3c7e595cb8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->