### PR TITLE
feat: add Moca 1.3.0 eip155

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -177,6 +177,7 @@
     "2201": ["canonical", "eip155"],
     "2221": ["canonical", "eip155"],
     "2222": ["canonical", "eip155"],
+    "2288": "eip155",
     "2331": "canonical",
     "2345": "canonical",
     "2358": "eip155",


### PR DESCRIPTION
## Add new chain
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2288

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0xdec7db02c4502552181ab8357f071332a882830a9b874069fb17725c45e367bf)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237871 gas
deploying "GnosisSafeProxyFactory" (tx: 0x92b19610aaf8656d58f803982811a22850374fcccaa15d3d954f474001b167f0)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867594 gas
deploying "DefaultCallbackHandler" (tx: 0xb08c6097bc7c00adbbfbc57cae8fe4b0b7b47cb1cdbecf10a864854ffc434892)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542473 gas
deploying "CompatibilityFallbackHandler" (tx: 0xcdab58701e457bbdf9c936d8c861572707d8c0450d024acce3c9a05dd63befdb)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238095 gas
deploying "CreateCall" (tx: 0x404f03661be524b71bc37d838efb3cd213aceda52f6085c8996772a4b25ddb01)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294718 gas
deploying "MultiSend" (tx: 0x05b751349dcabf1b30213c31062684161793ab11ddbf3b3a5233854b9e34e9cb)...: deployed at 0x998739BFdAAdde7C933B942a68053933098f9EDa with 190004 gas
deploying "MultiSendCallOnly" (tx: 0x75eb952e36b05ea47210d533486cee4a84a7964f3987dcb2d31d5c1f247dd736)...: deployed at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B with 142122 gas
deploying "SignMessageLib" (tx: 0x7c08b385b26234fa08966993927432b5172527c17bcd504c94d4efe60423ce33)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262353 gas
deploying "GnosisSafeL2" (tx: 0x88b66e7672d78b9ab44f7a474c05043d673a3f31a7173e46cf7b1f53bd6ba3f0)...: deployed at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA with 5200241 gas
deploying "GnosisSafe" (tx: 0xa70a15f594c914fc1730d51e03cd4728cc92d3250545942450b6eaf0e1d15567)...: deployed at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938 with 5017833 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds network support for chain ID `2288` by mapping it to `eip155` across Safe v1.3.0 assets.
> 
> - Updates `networkAddresses` in `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`, `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`, `sign_message_lib.json`, and `simulate_tx_accessor.json` to include `"2288": "eip155"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9904e621554646bb82b3b873cd728ef35783c0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->