### PR TITLE
feat: add Moca 1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -110,6 +110,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -110,6 +110,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -110,6 +110,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -130,6 +130,7 @@
     "2201": "canonical",
     "2221": "canonical",
     "2222": "canonical",
+    "2288": "canonical",
     "2345": "canonical",
     "2358": "canonical",
     "2390": "canonical",


### PR DESCRIPTION
## Add new chain
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2288

Relevant information:
```
deploying "SimulateTxAccessor" (tx: 0x574803b61062f0720f77b7ed96d5dead69b955f776a69f9c626b31e988ec7b42)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237871 gas
reusing "SafeProxyFactory" at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
deploying "TokenCallbackHandler" (tx: 0xb037420db3067637d88cfaa2dfa73f6831c50712ab34a6fc03251719ab97072b)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453288 gas
reusing "CompatibilityFallbackHandler" at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99
deploying "CreateCall" (tx: 0xa88e77dc2665f82d8d9e816fa87d381083002c45f821907ca12396e4a2b70080)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290398 gas
reusing "MultiSend" at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
deploying "MultiSendCallOnly" (tx: 0xc38153c483ea7da1b53b94a775da7f45e96949791a9e854f826b0ffade96ff96)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142122 gas
deploying "SignMessageLib" (tx: 0x1c5b84081661548ae765897ba74ee982eb10fd7e2cf72f006638e5bdf3bd4130)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262353 gas
deploying "SafeToL2Setup" (tx: 0x38308b53ab380e3e5f71d190895646fcb6cd8c229114178e713f65c1028d32eb)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230805 gas
deploying "Safe" (tx: 0x92ae14960f0bff07471d9208a63202a05e33dde1d88c13c03cc8b654d6aaabac)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5148594 gas
reusing "SafeL2" at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762
deploying "SafeToL2Migration" (tx: 0x271050779e0684b8fda07426772eb7010199da852de7427c9342fc3a6afa22c6)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1282712 gas
deploying "SafeMigration" (tx: 0x560d103b0146c1325d4ac088285e36b1eef59392c0d7bd36f082ce0db0908345)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512670 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for chain `2288` (Moca) across the Safe v1.4.1 artifact set, referencing existing canonical deployments.
> 
> - Updates `networkAddresses` with `2288: "canonical"` in `compatibility_fallback_handler.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`, `sign_message_lib.json`, and `simulate_tx_accessor.json`
> - No ABI or deployment metadata changes beyond adding the network mapping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5dfc6ad13b1052936a568d0977a273037077643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->