### PR TITLE
feat: add 1.4.1 contracts for DogeOS Chikyū Testnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -291,6 +291,7 @@
     "2632500": "canonical",
     "3441006": "canonical",
     "5064014": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7777777": "canonical",
     "11142220": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -291,6 +291,7 @@
     "2632500": "canonical",
     "3441006": "canonical",
     "5064014": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7777777": "canonical",
     "11142220": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -291,6 +291,7 @@
     "2632500": "canonical",
     "3441006": "canonical",
     "5064014": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7777777": "canonical",
     "11142220": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -347,6 +347,7 @@
     "3441006": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
+    "6281971": "canonical",
     "6985385": "canonical",
     "7225878": "canonical",
     "7777777": "canonical",


### PR DESCRIPTION
Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 6281971

Relevant information:

- [x] v1.4.1 Canonical contracts were deployed to network:

```
deploying "SimulateTxAccessor" (tx: 0x7917088116f778c398a6e69535f55f0267dc93bb2c7e76b08b27fa979519be06)...: deployed at 0x3d4BA2E0884aa488718476ca2FB8Efc291A46199 with 237931 gas
deploying "SafeProxyFactory" (tx: 0x9970d6dcaf8ba7cf27932808555602cec173fb23a7c60164107b3dd3f22b8a18)...: deployed at 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67 with 712622 gas
deploying "TokenCallbackHandler" (tx: 0x8eaa8375789de4c0515a5121e96b59ae0f44c48d3b1d02bd55c0c4e92b5552cb)...: deployed at 0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562 with 453406 gas
deploying "CompatibilityFallbackHandler" (tx: 0xdc08f24df26f5c56325068f555b3740d610e701865e3de7de700db5f9a12087f)...: deployed at 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99 with 1270132 gas
deploying "CreateCall" (tx: 0x898feb273aa8e118f968f84c6cdf703db44df29d968ffacfaa5017a25a2a4ee1)...: deployed at 0x9b35Af71d77eaf8d7e40252370304687390A1A52 with 290470 gas
deploying "MultiSend" (tx: 0x63e98f0f7d32c4b82e2ed8366949b441a03e5b775b7c86a96c12aa64abeb8c5d)...: deployed at 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526 with 190062 gas
deploying "MultiSendCallOnly" (tx: 0x9b4332cc2852462f197e49b4a6b43adbd0bf6b58dc0402db71fbdd39a4db8fad)...: deployed at 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 with 142150 gas
deploying "SignMessageLib" (tx: 0x1d775e2a7284ff27242460395e141f86509a51d36a8e04808ebdca54065b361c)...: deployed at 0xd53cd0aB83D845Ac265BE939c57F53AD838012c9 with 262417 gas
deploying "SafeToL2Setup" (tx: 0x9492da0f29ec9be0e77cc88dea94682056d6db7858ddf66fe0ab9ef8456c63dd)...: deployed at 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54 with 230863 gas
deploying "Safe" (tx: 0x512615ea6dc10e1f1c5a9827d814db6522f6c1d05ced200fc4365cb801192002)...: deployed at 0x41675C099F32341bf84BFc5382aF534df5C7461a with 5150072 gas
deploying "SafeL2" (tx: 0x79590a42180eaf56107021dcaa4e8d32e3817b45aa667aeeb8e252990c1b1dc6)...: deployed at 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762 with 5332531 gas
deploying "SafeToL2Migration" (tx: 0x6d805d05237d0304f3e316c9345f43e71d392ab16d3c6c4f674f357652cbd141)...: deployed at 0xfF83F6335d8930cBad1c0D439A841f01888D9f69 with 1283078 gas
deploying "SafeMigration" (tx: 0x25afb6e68c8326c65188051ff2cc27eb1ed05d1c47c127769f7f5cb0ea244c9c)...: deployed at 0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6 with 512858 gas
```


- [X] All deployed contracts were verified at [DogeOS Chikyū Testnet Explorer](https://blockscout.testnet.dogeos.com/)
  
  - __v1.4.1-canonical__
    - SimulateTxAccessor: [0x3d4BA2E0884aa488718476ca2FB8Efc291A46199](https://blockscout.testnet.dogeos.com/address/0x3d4ba2e0884aa488718476ca2fb8efc291a46199)
    - SafeProxyFactory: [0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67](https://blockscout.testnet.dogeos.com/address/0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67)
    - TokenCallbackHandler: [0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562](https://blockscout.testnet.dogeos.com/address/0xedcf620325e82e3b9836eaaefdc4283e99dd7562)
    - CompatibilityFallbackHandler: [0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99](https://blockscout.testnet.dogeos.com/address/0xfd0732dc9e303f09fcef3a7388ad10a83459ec99)
    - CreateCall: [0x9b35Af71d77eaf8d7e40252370304687390A1A52](https://blockscout.testnet.dogeos.com/address/0x9b35af71d77eaf8d7e40252370304687390a1a52)
    - MultiSend: [0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526](https://blockscout.testnet.dogeos.com/address/0x38869bf66a61cf6bdb996a6ae40d5853fd43b526)
    - MultiSendCallOnly: [0x9641d764fc13c8B624c04430C7356C1C7C8102e2](https://blockscout.testnet.dogeos.com/address/0x9641d764fc13c8b624c04430c7356c1c7c8102e2)
    - SignMessageLib: [0xd53cd0aB83D845Ac265BE939c57F53AD838012c9](https://blockscout.testnet.dogeos.com/address/0xd53cd0ab83d845ac265be939c57f53ad838012c9)
    - SafeToL2Setup: [0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54](https://blockscout.testnet.dogeos.com/address/0xbd89a1ce4dde368ffab0ec35506eece0b1ffdc54)
    - Safe: [0x41675C099F32341bf84BFc5382aF534df5C7461a](https://blockscout.testnet.dogeos.com/address/0x41675c099f32341bf84bfc5382af534df5c7461a)
    - SafeL2: [0x29fcB43b46531BcA003ddC8FCB67FFE91900C762](https://blockscout.testnet.dogeos.com/address/0x29fcb43b46531bca003ddc8fcb67ffe91900c762)
    - SafeToL2Migration: [0xfF83F6335d8930cBad1c0D439A841f01888D9f69](https://blockscout.testnet.dogeos.com/address/0xff83f6335d8930cbad1c0d439a841f01888d9f69)
    - SafeMigration: [0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6](https://blockscout.testnet.dogeos.com/address/0x526643f69b81b008f46d95cd5ced5ec0edffdac6)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for DogeOS Chikyū Testnet by mapping chain `6281971` to `canonical` in v1.4.1 artifact `networkAddresses`.
> 
> - Updates mappings in `Safe`, `SafeL2`, `SafeProxyFactory`, `MultiSend`, `MultiSendCallOnly`, `CreateCall`, `SignMessageLib`, `SimulateTxAccessor`, migration/setup contracts, and `CompatibilityFallbackHandler`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e76105fd18beb2e25631b574f237d13e00c4f516. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->