### PR TITLE
Added Testethiq 853211

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -383,6 +383,7 @@
     "764984": "canonical",
     "808813": ["eip155", "canonical"],
     "810180": "zksync",
+    "853211": "eip155",
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 853211

Relevant information:
Testethiq is an L2 testnet on the OP stack base chain L1 -> Sepolia  using op v5.0.0 contracts. Testethiq op-contracts/v5.0.0

explorer: https://explorer.testnet.ethiq.network

All contracts are verified on explorer.

deploying "SimulateTxAccessor" (tx: 0x4510701cf2abf296645dc498811c32074de98a1535814d6907f6efc2cd499a99)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0x7ae136bcaffd8a23c00d6e87e9ad26298f87c38d2d5013cf804dd7cd49bd29ab)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0x837697fd832df7ed67c917c13b4ab7a8fccb327e593d230df989548732565d0a)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0x27828fc649ace9c296fd25846ea27fa9bca3d729251ba62e4b86aedada2bc96e)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238441 gas
deploying "CreateCall" (tx: 0x9db63be0c0d7cd79707761abd7935356a3b4fff0de8a1692a78fe300979b6ae0)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294790 gas
reusing "MultiSend" at 0x998739BFdAAdde7C933B942a68053933098f9EDa
reusing "MultiSendCallOnly" at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B
deploying "SignMessageLib" (tx: 0xbfbb577012b51d30658f9076293b805e2bfa488dd7146d1c77d3c40bd4e25e56)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262417 gas
reusing "GnosisSafeL2" at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA
reusing "GnosisSafe" at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for chain `853211` (Testethiq) by mapping it to `"eip155"` in Safe v1.3.0 assets.
> 
> - Updates `networkAddresses` with `"853211": "eip155"` in `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`, `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`, `sign_message_lib.json`, and `simulate_tx_accessor.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9d4620ec041a82ea32ac9267d2346495181003a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->