### PR TITLE
feat: add 1.3.0 contracts for Saga EVM Mainnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -211,6 +211,7 @@
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
+    "5464": ["eip155", "canonical"],
     "5700": ["eip155", "canonical"],
     "5887": ["eip155", "canonical"],
     "5888": ["eip155", "canonical"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 5464

Relevant information:
- eip155:
```
deploying "SimulateTxAccessor" (tx: 0x81e81739e9d5005a3abdd5c485944c21a47a59b8bc82a84a6bf78a7b5b48a69c)...: deployed at 0x727a77a074D1E6c4530e814F89E618a3298FC044 with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0x2014763f8b4f9a3a0b7e707d5e802af2def5cb980e7ebd3850ba1ef271ab5991)...: deployed at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0xb27908afa05a7473eb7b8249e89b1da02ceed20e106c435692167cf66fdabb09)...: deployed at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3 with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0xb5a54ef4a2729e0e6b4d2116cdc37562e84d6fdce7ae9c169f1c75cfe0a5a8a7)...: deployed at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804 with 1238441 gas
deploying "CreateCall" (tx: 0x5a89c0ff0ecb55d4d4537f53d9770ea27fd3c14e5a0f30d25ce02808b3d87023)...: deployed at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d with 294790 gas
deploying "MultiSend" (tx: 0x88c46276b83933921a754c087e29a4dfabfb8f0c6b94f8a456826f86b0760f3d)...: deployed at 0x998739BFdAAdde7C933B942a68053933098f9EDa with 190050 gas
deploying "MultiSendCallOnly" (tx: 0xea8365d313959187242cbc6b4a4312664b176b1a5fae2e7a4ddfc70f2652673d)...: deployed at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B with 142150 gas
deploying "SignMessageLib" (tx: 0x421bb81c0cf4bf9947587e4b5a81654ce6d37c16c6ceec35eca8e2bf12927fc1)...: deployed at 0x98FFBBF51bb33A056B08ddf711f289936AafF717 with 262417 gas
deploying "GnosisSafeL2" (tx: 0x19b72d9304a0ee8a5a69a85d50b68f1a67961a052cdaff1865f56dd6b0aeea8d)...: deployed at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA with 5201733 gas
deploying "GnosisSafe" (tx: 0x4821517ac7d6a2dec60061d272bd97fe678e960cc70292c06133d689c57f5019)...: deployed at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938 with 5019271 gas
```

- canonical:
```
deploying "SimulateTxAccessor" (tx: 0x634251f312634a5c5cc13be677ec882049bb3e5547656f74f6dbd2576b3e3daa)...: deployed at 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da with 237931 gas
deploying "GnosisSafeProxyFactory" (tx: 0x87c034cab38cd0a69329214f43e163393275953dbe1ff068c5f8765bc5c440bb)...: deployed at 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 with 867832 gas
deploying "DefaultCallbackHandler" (tx: 0x7efcff1eaac8f336c207155230daf5613c207c3a65b3f737e2ab84599b947a90)...: deployed at 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd with 542617 gas
deploying "CompatibilityFallbackHandler" (tx: 0x476d76b7945938c22c9304a493761762eddb5b9eae542714cb7235003928587d)...: deployed at 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4 with 1238441 gas
deploying "CreateCall" (tx: 0x002d2d045da561849407970fc8ddcc43e23d8debba6f4105213c8486c9344c06)...: deployed at 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4 with 294790 gas
deploying "MultiSend" (tx: 0xfa16d8cd4d1f56399ff21dbb3be3a8782b66d6e5e3746f1e384a6bcef939e2ab)...: deployed at 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761 with 190050 gas
deploying "MultiSendCallOnly" (tx: 0xb2ed98d7a883a8be33afeb0cec79885d552fa69e7183fe4ed8b62f3c79bc1525)...: deployed at 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D with 142150 gas
deploying "SignMessageLib" (tx: 0x75f364210c823581916c1163d6874d050c7cd43386d365f51c7bdfcf09d82773)...: deployed at 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2 with 262417 gas
deploying "GnosisSafeL2" (tx: 0x2523cc5aa4e1943667833fbe4a02c39ca4714341eb5059e45bfe61f996da17fb)...: deployed at 0x3E5c63644E683549055b9Be8653de26E0B4CD36E with 5201733 gas
deploying "GnosisSafe" (tx: 0xca92aa301451dbd80797f5aa380c7510149bbc893065f3157adbcc731fc3695c)...: deployed at 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 with 5019271 gas
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Saga EVM Mainnet support by mapping chain `5464` to `["eip155", "canonical"]` across v1.3.0 assets.
> 
> - Update `networkAddresses` in `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`, `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`, `sign_message_lib.json`, and `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3a905b2a1afc2613ae19ae539ac73786c6b5de8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->