### PR TITLE
Add Alpen Testnet 1.5.0 contracts addresses

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -17,6 +17,7 @@
     "4326": "canonical",
     "5424": "canonical",
     "5887": "canonical",
+    "8150": "canonical",
     "9302": "canonical",
     "20994": "canonical",
     "32380": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 8150

Relevant information:
- Blockexplorer: https://explorer.pectra-testnet.alpenlabs.io/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for chain `8150` by mapping it to the canonical deployments for all Safe v1.5.0 artifacts.
> 
> - Updates `networkAddresses` to include `"8150": "canonical"` across `safe*.json`, `multi_send*.json`, `create_call.json`, `simulate_tx_accessor.json`, `sign_message_lib.json`, `token_callback_handler.json`, `compatibility_fallback_handler.json`, and `extensible_fallback_handler.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a49b43bb911fc04c189381e4c84e7a03bbb7691a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->