### PR TITLE
Add Bridgeless Mainnet network (v1.4.1)

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -179,6 +179,7 @@
     "11011": "canonical",
     "11124": ["zksync", "canonical"],
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -179,6 +179,7 @@
     "11011": "canonical",
     "11124": ["zksync", "canonical"],
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -179,6 +179,7 @@
     "11011": "canonical",
     "11124": ["zksync", "canonical"],
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -218,6 +218,7 @@
     "11503": "canonical",
     "13337": "canonical",
     "13371": "canonical",
+    "13441": "canonical",
     "13473": "canonical",
     "13505": "canonical",
     "13746": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 13441

Relevant information:
Explorer URL: https://explorer.mainnet.bridgeless.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Bridgeless Mainnet (chain `13441`) support to Safe v1.4.1 assets by mapping it to `canonical` across contract metadata.
> 
> - Updates `networkAddresses` to include `13441: "canonical"` in `compatibility_fallback_handler.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`, `sign_message_lib.json`, and `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf61f3f792efbcf647c988a755d9587a280f34cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->