### PR TITLE
feat: add 1.3.0 contracts for Anq Chain Testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -259,6 +259,7 @@
     "11111": "canonical",
     "11124": ["zksync", "canonical", "eip155"],
     "11235": "canonical",
+    "11417": "canonical",
     "11437": "canonical",
     "11820": "canonical",
     "11891": "canonical",


### PR DESCRIPTION
## Add new chain

> This PR adds Anq Chain Testnet (ChainID: 11417) deployment addresses for all Safe v1.3.0 contracts.

**Network Details** -
Name: Anq Testnet 
Chain_ID: 11417
RPC: https://rpc-public-test.anq.world/
Explorer: https://blockscout-test.anq.world/

**Deployment Details** -
Safe Version: 1.3.0
Deployment Type: Canonical (deterministic deployment)
Files Changed: 9

All deployed addresses match the canonical Safe v1.3.0 addresses:

```
CompatibilityFallbackHandler: 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4
CreateCall: 0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4
DefaultCallbackHandler: 0x1AC114C2099aFAf5261731655Dc6c306bFcd4Dbd
GnosisSafe: 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552
GnosisSafeL2: 0x3E5c63644E683549055b9Be8653de26E0B4CD36E
GnosisSafeProxyFactory: 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2
MultiSend: 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761
MultiSendCallOnly: 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D
SignMessageLib: 0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2
SimulateTxAccessor: 0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da
```

Verification
✅ Addresses verified against canonical deployments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Anq Chain Testnet support by mapping `11417` to the `canonical` deployment set across Safe v1.3.0 asset files.
> 
> - Updates `networkAddresses` in `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`, `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`, `sign_message_lib.json`, and `simulate_tx_accessor.json` to include `11417: "canonical"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b31d2e182906a64272d28a33b4f445b9dea5fa3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->