### PR TITLE
add all contracts for arc testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -391,6 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
+    "5042002": ["canonical", "eip155"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -292,6 +292,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6281971": "canonical",
     "6985385": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -292,6 +292,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6281971": "canonical",
     "6985385": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -292,6 +292,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6281971": "canonical",
     "6985385": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -31,6 +31,7 @@
     "843843": "canonical",
     "1440000": "canonical",
     "1449000": "canonical",
+    "5042002": "canonical",
     "11155111": "canonical"
   },
   "abi": [


### PR DESCRIPTION
- Chain_ID: 5042002


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Arc testnet support by extending `networkAddresses` with chain `5042002` across Safe assets.
> 
> - v1.3.0: update `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`, `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`, `sign_message_lib.json`, `simulate_tx_accessor.json` to include `5042002` mapped to `"canonical"` and `"eip155"`
> - v1.4.1: update `compatibility_fallback_handler.json`, `create_call.json`, `multi_send.json`, `multi_send_call_only.json`, `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`, `safe_to_l2_migration.json`, `safe_to_l2_setup.json`, `sign_message_lib.json`, `simulate_tx_accessor.json` to include `5042002` mapped to `"canonical"`
> - v1.5.0: update `compatibility_fallback_handler.json`, `create_call.json`, `extensible_fallback_handler.json`, `multi_send.json`, `multi_send_call_only.json`, `safe.json`, `safe_l2.json`, `safe_migration.json`, `safe_proxy_factory.json`, `safe_to_l2_setup.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`, `token_callback_handler.json` to include `5042002` mapped to `"canonical"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6f0123477f1eb32ddd2237f4187542ba2d9aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->