### PR TITLE
chores: add 1.3.0 contracts for arc testnet

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -391,7 +391,7 @@
     "978657": "canonical",
     "1000101": "canonical",
     "4457845": "zksync",
-    "5042002": ["canonical", "eip155"],
+    "5042002": ["eip155", "canonical"],
     "5064014": ["eip155", "canonical"],
     "6038361": ["eip155", "canonical"],
     "6281971": ["eip155", "canonical"],


### PR DESCRIPTION
Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 5042002

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Arc testnet support by mapping chain `5042002` to `eip155` and `canonical` for v1.3.0 artifacts.
> 
> - Updates `networkAddresses` with `5042002` in: `compatibility_fallback_handler.json`, `create_call.json`, `gnosis_safe.json`, `gnosis_safe_l2.json`, `multi_send.json`, `multi_send_call_only.json`, `proxy_factory.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47bc5a8539a20f465857adf796c50211b9ccbee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->