### PR TITLE
chores: add 1.4.1 contracts for arc testnet

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -292,6 +292,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6281971": "canonical",
     "6985385": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -292,6 +292,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6281971": "canonical",
     "6985385": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -292,6 +292,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6281971": "canonical",
     "6985385": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -347,6 +347,7 @@
     "2206132": "canonical",
     "2632500": "canonical",
     "3441006": "canonical",
+    "5042002": "canonical",
     "5064014": "canonical",
     "6038361": "canonical",
     "6281971": "canonical",


### PR DESCRIPTION

- Chain_ID: 5042002

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Arc testnet by mapping `5042002` to `canonical` in `networkAddresses` across v1.4.1 Safe assets.
> 
> - Updated `networkAddresses` in multiple artifacts (e.g., `safe`, `safe_l2`, `safe_proxy_factory`, `multi_send`, `multi_send_call_only`, `create_call`, `simulate_tx_accessor`, `compatibility_fallback_handler`, `sign_message_lib`, `safe_migration`, `safe_to_l2_migration`, `safe_to_l2_setup`) to include `5042002`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5cc6d583280d5ac2a6f6a23f025deb964f89f4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->