### PR TITLE
feat(add): Add Creator Testnet v1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -264,6 +264,7 @@
     "200901": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -264,6 +264,7 @@
     "200901": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -264,6 +264,7 @@
     "200901": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -315,6 +315,7 @@
     "205205": "canonical",
     "210425": "canonical",
     "222888": "canonical",
+    "278701": "canonical",
     "314159": "canonical",
     "325000": "canonical",
     "369369": "canonical",


### PR DESCRIPTION
## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 278701

Relevant information:
Block Explorer: https://block-explorer.zksync-os-testnet-creator.zksync.dev/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Creator Testnet support by mapping chain ID `278701` to `canonical` across v1.4.1 artifacts.
> 
> - Updates `networkAddresses` in `safe*.json`, `multi_send*.json`, `create_call.json`, `sign_message_lib.json`, `simulate_tx_accessor.json`, and migration/setup artifacts to include `278701: canonical`
> - No changes to ABIs or deployment addresses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edfca5f1537168e925263376488b1d0733e0f11f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->