### PR TITLE
Add Gensyn (685689) to v1.4.1 deployments

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -333,6 +333,7 @@
     "560048": "canonical",
     "656476": "canonical",
     "657468": "canonical",
+    "685689": "canonical",
     "688688": "canonical",
     "688689": "canonical",
     "695569": "canonical",


### PR DESCRIPTION
## Summary
- Adds Gensyn (chain ID 685689) to all v1.4.1 contract deployment registries
- Gensyn is an OP Stack chain
- All contracts deployed at canonical addresses via the pre-installed Safe Singleton Factory

## Contracts deployed
| Contract | Address |
|---|---|
| Safe | `0x41675C099F32341bf84BFc5382aF534df5C7461a` |
| SafeL2 | `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762` |
| SafeProxyFactory | `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67` |
| CompatibilityFallbackHandler | `0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99` |
| CreateCall | `0x9b35Af71d77eaf8d7e40252370304687390A1A52` |
| MultiSend | `0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526` |
| MultiSendCallOnly | `0x9641d764fc13c8B624c04430C7356C1C7C8102e2` |
| SignMessageLib | `0xd53cd0aB83D845Ac265BE939c57F53AD838012c9` |
| SimulateTxAccessor | `0x3d4BA2E0884aa488718476ca2FB8Efc291A46199` |