### PR TITLE
feat: add Citrea Mainnet deploys for 1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -131,6 +131,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "4061": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -131,6 +131,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "4061": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -131,6 +131,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "4061": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -154,6 +154,7 @@
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",
+    "4114": "canonical",
     "4153": "canonical",
     "4157": "canonical",
     "4158": "canonical",


### PR DESCRIPTION
## Add new chain (v1.4.1)

- Chain_ID: 4114

Relevant information:
- RPC_URL: https://rpc.mainnet.citrea.xyz/
- Block explorer:
https://explorer.mainnet.citrea.xyz/