### PR TITLE
Add Ethereum Classic (61) to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -24,6 +24,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "81": "canonical",
     "88": "canonical",
     "98": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -24,6 +24,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "81": "canonical",
     "88": "canonical",
     "98": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -24,6 +24,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "81": "canonical",
     "88": "canonical",
     "98": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -30,6 +30,7 @@
     "50": "canonical",
     "51": "canonical",
     "56": "canonical",
+    "61": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).

- Chain_ID: 61

Relevant information:

- Network name: Ethereum Classic
- Explorer: https://etc.blockscout.com
- Safe version: v1.4.1
- Deployment type: canonical
- All 12 contracts verified on Blockscout (exact match)

Note: a companion PR for Mordor testnet (chain 63) is also open at #1456. Both add a line after "56" so the second to merge will need a trivial rebase.