### PR TITLE
Add Ethereum Classic Mordor testnet (63) to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -25,6 +25,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "81": "canonical",
     "88": "canonical",
     "98": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -25,6 +25,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "81": "canonical",
     "88": "canonical",
     "98": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -25,6 +25,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "81": "canonical",
     "88": "canonical",
     "98": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -31,6 +31,7 @@
     "51": "canonical",
     "56": "canonical",
     "61": "canonical",
+    "63": "canonical",
     "71": "canonical",
     "81": "canonical",
     "88": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).

- Chain_ID: 63

Relevant information:

- Network name: Mordor (Ethereum Classic testnet)
- Explorer: https://etc-mordor.blockscout.com
- Safe version: v1.4.1
- Deployment type: canonical
- All 12 contracts verified on Blockscout (exact match)

Note: a companion PR for ETC Classic mainnet (chain 61) is also open at #1455. Both add a line after "56" so the second to merge will need a trivial rebase.