### PR TITLE
feat: add Status Network Hoodi 1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -55,6 +55,7 @@
     "324": ["zksync", "canonical"],
     "336": "canonical",
     "360": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -55,6 +55,7 @@
     "324": ["zksync", "canonical"],
     "336": "canonical",
     "360": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -55,6 +55,7 @@
     "324": ["zksync", "canonical"],
     "336": "canonical",
     "360": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -69,6 +69,7 @@
     "338": "canonical",
     "360": "canonical",
     "369": "canonical",
+    "374": "canonical",
     "466": "canonical",
     "478": "canonical",
     "480": "canonical",


### PR DESCRIPTION
Add chain ID 374 (Status Network Hoodi) to v1.4.1 registry entries for canonical deployment.

## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 374

Relevant information:
https://hoodiscan.status.network/
