### PR TITLE
feat: add Status Network Hoodi 1.3.0 canonical

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -97,6 +97,7 @@
     "338": "eip155",
     "360": ["eip155", "canonical"],
     "369": "canonical",
+    "374": "canonical",
     "388": "zksync",
     "418": "canonical",
     "420": "eip155",


### PR DESCRIPTION
Add chain ID 374 (Status Network Hoodi) to v1.3.0 canonical registry.

## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 374

Relevant information:
https://hoodiscan.status.network/
