### PR TITLE
Add chain Moca Chain Testnet to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -65,6 +65,7 @@
     "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
+    "222888": "canonical",
     "369369": "canonical",
     "560048": "canonical",
     "613419": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 222888

Relevant information:
- Network: Moca Chain Testnet
- Explorer: https://testnet-scan.mocachain.org (Blockscout)
- Safe version: v1.5.0
- Deployment type: canonical