### PR TITLE
Add chain Alpen Testnet to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -23,6 +23,7 @@
     "5887": "canonical",
     "7979": "canonical",
     "8150": "canonical",
+    "8150": "canonical",
     "8453": "canonical",
     "9302": "canonical",
     "13441": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 8150

Relevant information:
- Network: Alpen Testnet II
- Explorer: https://explorer.testnet.alpenlabs.io (Blockscout)
- Safe version: v1.5.0
- Deployment type: canonical