### PR TITLE
Add Taiko Hoodi to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -36,6 +36,7 @@
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",
+    "167013": "canonical",
     "181228": "canonical",
     "190415": "canonical",
     "369369": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 167013

Relevant information:
- Network: Taiko Hoodi
- Explorer: https://hoodi.taikoscan.io (Etherscan V2)
- Safe version: v1.5.0
- Deployment type: canonical