### PR TITLE
Add Lisk Sepolia to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -16,6 +16,7 @@
     "1995": "canonical",
     "2201": "canonical",
     "4153": "canonical",
+    "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
     "5003": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4202

Relevant information:
- Network: Lisk Sepolia
- Explorer: https://sepolia-blockscout.lisk.com (Blockscout)
- Safe version: v1.5.0
- Deployment type: canonical