### PR TITLE
Add RSK Testnet to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -10,6 +10,7 @@
   },
   "networkAddresses": {
     "1": "canonical",
+    "31": "canonical",
     "63": "canonical",
     "756": "canonical",
     "757": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 31

Relevant information:
- Network: RSK Testnet
- Explorer: https://explorer.testnet.rsk.co (Custom explorer)
- Safe version: v1.5.0
- Deployment type: canonical