### PR TITLE
Add Kava to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -15,6 +15,7 @@
     "757": "canonical",
     "1995": "canonical",
     "2201": "canonical",
+    "2222": "canonical",
     "4153": "canonical",
     "4217": "canonical",
     "4326": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 2222

Relevant information:
- Network: Kava
- Explorer: https://kavascan.com (Blockscout)
- Safe version: v1.5.0
- Deployment type: canonical