### PR TITLE
Add ADI Network to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -29,6 +29,7 @@
     "20994": "canonical",
     "25363": "canonical",
     "32380": "canonical",
+    "36900": "canonical",
     "38833": "canonical",
     "42431": "canonical",
     "46630": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 36900

Relevant information:
- Network: ADI Network
- Explorer: https://explorer.adifoundation.ai
- Safe version: v1.5.0
- Deployment type: canonical