### PR TITLE
feat(add): Add Nexus Mainnet - Safe Contract v1.3.0

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -193,6 +193,7 @@
     "3637": ["canonical", "eip155"],
     "3737": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4078": "canonical",
     "4153": "canonical",


### PR DESCRIPTION
## Summary
- Add Nexus Mainnet chain ID 3946 as canonical for Safe Contract v1.3.0 assets

## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 3946

Relevant information:
https://explorer.nexus.xyz/


## Validation
- npm run lint:fix