### PR TITLE
feat(add): Add Nexus Mainnet - Safe Contracts v1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -130,6 +130,7 @@
     "3501": "canonical",
     "3636": "canonical",
     "3637": "canonical",
+    "3946": "canonical",
     "4061": "canonical",
     "4153": "canonical",
     "4157": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -130,6 +130,7 @@
     "3501": "canonical",
     "3636": "canonical",
     "3637": "canonical",
+    "3946": "canonical",
     "4061": "canonical",
     "4153": "canonical",
     "4157": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -130,6 +130,7 @@
     "3501": "canonical",
     "3636": "canonical",
     "3637": "canonical",
+    "3946": "canonical",
     "4061": "canonical",
     "4153": "canonical",
     "4157": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -151,6 +151,7 @@
     "3636": "canonical",
     "3637": "canonical",
     "3776": "canonical",
+    "3946": "canonical",
     "4002": "canonical",
     "4061": "canonical",
     "4062": "canonical",


### PR DESCRIPTION
## Summary
- Add Nexus Mainnet chain ID 3946 as canonical for Safe Contracts v1.4.1 assets

## Add new chain

> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 3946

Relevant information:
https://explorer.nexus.xyz/

## Validation
- npm run lint:fix