### PR TITLE
Add LitVM Liteforge Testnet to v1.3.0 registry

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -202,6 +202,7 @@
     "4217": ["eip155", "canonical"],
     "4326": ["eip155", "canonical"],
     "4337": "canonical",
+    "4441": "canonical",
     "4460": "canonical",
     "4509": "canonical",
     "4653": "eip155",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4441

Relevant information:
- Network: LitVM Liteforge Testnet
- Explorer: https://liteforge.explorer.caldera.xyz/ (Blockscout)
- Safe version: v1.3.0
- Deployment type: canonical