### PR TITLE
Add LitVM Liteforge Testnet to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -137,6 +137,7 @@
     "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4661": "canonical",
     "4801": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -137,6 +137,7 @@
     "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4661": "canonical",
     "4801": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -137,6 +137,7 @@
     "4202": "canonical",
     "4217": "canonical",
     "4326": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4661": "canonical",
     "4801": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -162,6 +162,7 @@
     "4217": "canonical",
     "4326": "canonical",
     "4337": "canonical",
+    "4441": "canonical",
     "4488": "canonical",
     "4653": "canonical",
     "4661": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 4441

Relevant information:
- Network: LitVM Liteforge Testnet
- Explorer: https://liteforge.explorer.caldera.xyz/ (Blockscout)
- Safe version: v1.4.1
- Deployment type: canonical