### PR TITLE
feat(add): Add Kiichain Mainnet to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -119,6 +119,7 @@
     "1740": "canonical",
     "1750": "canonical",
     "1776": "canonical",
+    "1783": "canonical",
     "1811": "canonical",
     "1868": "canonical",
     "1923": "canonical",


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1783

Relevant information:
- Network: Kiichain
- RPC: https://rpc.kiivalidator.com/status
- Safe version: v1.4.1