### PR TITLE
fix(types): always return networkAddresses as string[] in SingletonDeploymentV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ export interface SingletonDeployment {
   // Ex: deployments: { "canonical": { "codeHash": "0x1234", "address": "0x5678"}}
   deployments: Record<string, { address: string; codeHash: string }>;
 
-  // A record of network addresses, where the key is the network identifier and the value is the address.
-  networkAddresses: Record<string, string | string[]>;
+  // A record of network addresses, where the key is the network identifier and the value is the list of addresses deployed for that network.
+  // Networks with a single deployment expose a one-element array, so consumers always work with `string[]`.
+  networkAddresses: Record<string, string[]>;
 
   // The ABI (Application Binary Interface) of the contract.
   abi: any[];

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -448,8 +448,8 @@ describe('utils.ts', () => {
             },
           },
           networkAddresses: {
-            '1': '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-            '100': '0xbabebabebabebabebabebabebabebabebabebabe',
+            '1': ['0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef'],
+            '100': ['0xbabebabebabebabebabebabebabebabebabebabe'],
             '101': ['0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef', '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe'],
           },
           released: true,
@@ -461,6 +461,40 @@ describe('utils.ts', () => {
         const testDeployments = [testReleasedDeploymentJson];
 
         expect(findDeployment({}, testDeployments, DeploymentFormats.MULTIPLE)).toMatchObject(expectedDeployment);
+      });
+
+      it('should always return networkAddresses entries as arrays', () => {
+        const testDeploymentJson: SingletonDeploymentJSON = {
+          version: '',
+          abi: [],
+          deployments: {
+            canonical: {
+              address: '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+            eip155: {
+              address: '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe',
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+          },
+          networkAddresses: { '1': 'canonical', '5': ['canonical', 'eip155'] },
+          contractName: '',
+          released: true,
+        };
+
+        const result = findDeployment({}, [testDeploymentJson], DeploymentFormats.MULTIPLE);
+
+        expect(result).toBeDefined();
+        // Every value of networkAddresses should be an array, so consumers can iterate without
+        // branching on `string | string[]`.
+        for (const value of Object.values(result!.networkAddresses)) {
+          expect(Array.isArray(value)).toBe(true);
+        }
+        expect(result!.networkAddresses['1']).toEqual(['0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef']);
+        expect(result!.networkAddresses['5']).toEqual([
+          '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          '0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeebabe',
+        ]);
       });
     });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,9 @@ export interface SingletonDeploymentV2 {
   deployments: AtLeastOne<Record<AddressType, { address: string; codeHash: string }>>;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   abi: any[];
-  networkAddresses: Record<string, string | string[]>;
+  // A record of network addresses, where the key is the network identifier and the value is the list of addresses deployed for that network.
+  // Single-address entries are represented as an array with one element, so consumers do not need to handle a `string | string[]` union.
+  networkAddresses: Record<string, string[]>;
 }
 
 export interface DeploymentFilter {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ import {
   SingletonDeploymentJSON,
   DeploymentFormats,
   SingletonDeploymentV2,
-  AddressType,
 } from './types';
 import semverSatisfies from 'semver/functions/satisfies';
 
@@ -43,8 +42,10 @@ const mapJsonToDeploymentsFormatV1 = (deployment: SingletonDeploymentJSON): Sing
  * Maps a SingletonDeploymentJSON object to a SingletonDeploymentV2 object.
  *
  * This function transforms the `networkAddresses` field of the deployment JSON object.
- * It converts each entry in `networkAddresses` to an array of addresses, using the `addresses` field
- * to resolve each address type.
+ * It converts every entry in `networkAddresses` to an array of resolved addresses, using
+ * the `deployments` field to resolve each address type. Single-address entries are wrapped
+ * in a one-element array, so consumers always work with `string[]` and do not have to
+ * branch on `string | string[]`.
  *
  * @param {SingletonDeploymentJSON} deployment - The deployment JSON object to map.
  * @returns {SingletonDeploymentV2} - The mapped deployment object in V2 format.
@@ -52,13 +53,12 @@ const mapJsonToDeploymentsFormatV1 = (deployment: SingletonDeploymentJSON): Sing
 const mapJsonToDeploymentsFormatV2 = (deployment: SingletonDeploymentJSON): SingletonDeploymentV2 => ({
   ...deployment,
   networkAddresses: Object.fromEntries(
-    Object.entries(deployment.networkAddresses).map(([chainId, addressTypes]) => [
-      chainId,
-      (Array.isArray(addressTypes)
-        ? // The usage of non-null assertion below is safe, because we validate that the asset files are properly formed in tests
-          (addressTypes.map((addressType) => deployment.deployments[addressType]!.address) as AddressType[])
-        : deployment.deployments[addressTypes]!.address) as AddressType,
-    ]),
+    Object.entries(deployment.networkAddresses).map(([chainId, addressTypes]) => {
+      const types = Array.isArray(addressTypes) ? addressTypes : [addressTypes];
+      // The usage of non-null assertion below is safe, because we validate that the asset files are properly formed in tests
+      const addresses = types.map((addressType) => deployment.deployments[addressType]!.address);
+      return [chainId, addresses];
+    }),
   ),
 });
 


### PR DESCRIPTION
## Summary

Closes #808.

`SingletonDeploymentV2.networkAddresses` is currently typed as `Record<string, string | string[]>`, which forces every consumer to branch on the union (or write a helper that coerces it into an array). The original issue lists three concrete cases of this in the safe-global stack:

- `safe-wallet-web/src/services/contracts/deployments.ts` (helper to coerce)
- `safe-client-gateway/src/domain/common/utils/deployments.ts` (helper to coerce)
- `safe-core-sdk/packages/protocol-kit/src/contracts/config.ts` (inline branch)

This PR changes the type to `Record<string, string[]>` and updates `mapJsonToDeploymentsFormatV2` so that single-address entries from the JSON source are wrapped in a one-element array. The on-disk JSON schema (`SingletonDeploymentJSON.networkAddresses: Record<string, AddressType | AddressType[]>`) is unchanged — the normalisation happens entirely in the mapper.

This also fixes a stale cast in `mapJsonToDeploymentsFormatV2` where the resolved value was asserted as `AddressType` even though resolution returns a deployment address (`string`).

## Breaking change

This is a breaking change for any consumer that reads `SingletonDeploymentV2.networkAddresses` and currently branches on `string` vs `string[]`. The migration is to drop the branch: every value is now a `string[]`, with single-address entries as one-element arrays.

This matches the shape the issue author proposed verbatim:

```ts
networkAddresses: Record<string, string[]>;
```

## Changes

- `src/types.ts` — narrow `SingletonDeploymentV2.networkAddresses` from `Record<string, string | string[]>` to `Record<string, string[]>` and add a clarifying comment.
- `src/utils.ts` — `mapJsonToDeploymentsFormatV2` now always emits an array, and the stale `AddressType` cast is gone. The non-null assertion is preserved (the assets test still guarantees every referenced address type exists).
- `src/__tests__/utils.test.ts` — update the existing V2 expectation and add a regression test that asserts every value of `networkAddresses` is an array after V2 mapping.
- `README.md` — update the V2 doc snippet to match.

## Validation

```
pnpm --ignore-workspace build  # tsc passes
pnpm --ignore-workspace test   # 169/169 passing
pnpm --ignore-workspace lint   # eslint + prettier clean
```