### PR TITLE
feat: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -5,12 +5,13 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -4,12 +4,13 @@ on:
     - cron: '0 10 * * 1' # Every Monday at 10:00 UTC
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,12 +2,13 @@ name: Publish Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -11,11 +11,12 @@ on:
         required: true
         type: number
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   review:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,12 @@ on:
   push:
     branches:
       - main
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -28,6 +28,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   update-registry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set permissions: {} at workflow level and grant minimum required scopes per job following principle of least privilege (contents: read for test, contents: write + pull-requests: write for release/registry workflows, pull-requests: write for review).
