### PR TITLE
Add Irys Mainnet to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -28,6 +28,7 @@
     "2221": "canonical",
     "2222": "canonical",
     "2391": "canonical",
+    "3282": "canonical",
     "4153": "canonical",
     "4202": "canonical",
     "4217": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill in the following form:

Provide the Chain ID (Only 1 chain ID per PR).
- Chain_ID: 3282

Relevant information:
- Network: Irys Mainnet
- Explorer: https://explorer.irys.xyz
- Safe version: v1.5.0
- Deployment type: canonical