### PR TITLE
Add Japan Open Chain Testnet v1.5.0 canonical deployments

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -41,6 +41,7 @@
     "8453": "canonical",
     "9302": "canonical",
     "9746": "canonical",
+    "10081": "canonical",
     "11011": "canonical",
     "13441": "canonical",
     "13473": "canonical",


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 10081

Relevant information:
- Block Explorer: https://explorer.testnet.japanopenchain.org/
- Safe version: 1.5.0
- Deployment type: canonical