### PR TITLE
Add Japan Open Chain Mainnet v1.5.0 canonical deployments

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -12,6 +12,7 @@
     "1": "canonical",
     "31": "canonical",
     "63": "canonical",
+    "81": "canonical",
     "338": "canonical",
     "545": "canonical",
     "756": "canonical",


### PR DESCRIPTION
## Add new chain

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 81

Relevant information:
- Block Explorer: https://explorer.japanopenchain.org/
- Safe version: 1.5.0
- Deployment type: canonical