### PR TITLE
fix: swap deployment order for chain 5042 in v1.3.0 registry

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -213,7 +213,7 @@
     "5000": ["eip155", "canonical"],
     "5001": "eip155",
     "5003": ["eip155", "canonical"],
-    "5042": ["canonical", "eip155"],
+    "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
     "5165": "canonical",
     "5330": ["eip155", "canonical"],


### PR DESCRIPTION
- Related with https://github.com/safe-global/safe-deployments/pull/1558

Fixes the deployment type order for chain 5042 in all v1.3.0 contracts, setting `eip155` before `canonical`.
