### PR TITLE
chore: add CONTRIBUTING.md guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Add new chain
 
-> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-contracts](https://github.com/safe-global/safe-contracts). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). This entire paragraph should be deleted.
+> Template to provide information about the new chain. Only add extra information in the bottom section. Ensure that the contracts are deployed on the chain, if not deploy with [safe-smart-account](https://github.com/safe-fndn/safe-smart-account). Only **one** chain ID, **one** Safe version and **one** deployment type per PR. The RPC will be taken from [DefiLlama's ChainList](https://chainlist.org/). Please read the [contributing guide](../CONTRIBUTING.md) before submitting. This entire paragraph should be deleted.
 
 Please fill the following form:
 

--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -79,11 +79,11 @@ jobs:
           if [ "$VERSION" = "v1.3.0-both" ]; then
             echo "Running for both v1.3.0 deployment types..."
             pnpm run update-registry \
-              --version "v1.3.0-canonical" \
+              --version "v1.3.0-eip155" \
               --chainId "$CHAIN_ID" \
               --verbose
             pnpm run update-registry \
-              --version "v1.3.0-eip155" \
+              --version "v1.3.0-canonical" \
               --chainId "$CHAIN_ID" \
               --verbose
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,15 @@ pnpm update-registry --version v1.5.0 --chainId <CHAIN_ID> --deploymentType cano
 Valid versions: `v1.0.0`, `v1.1.1`, `v1.2.0`, `v1.3.0`, `v1.4.1`, `v1.5.0`  
 Valid deployment types: `canonical`, `eip155`, `zksync`
 
+For `v1.3.0` chains that support both `eip155` and `canonical`, run `eip155` first:
+
+```bash
+pnpm update-registry --version v1.3.0-eip155 --chainId <CHAIN_ID>
+pnpm update-registry --version v1.3.0-canonical --chainId <CHAIN_ID>
+```
+
+This ensures the deployment type order is `["eip155", "canonical"]`. The exception is chains that were already registered with only `canonical` — in that case, `canonical` stays first to preserve backwards compatibility.
+
 ## Before pushing
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Safe Deployments
+
+This repository is the canonical registry of Safe smart contract deployments across blockchain networks. Contributing means adding a new chain or deployment type to one of the supported Safe versions.
+
+## Before you open a PR
+
+- **Contracts must already be deployed** on the target chain. If not, follow the deployment instructions in [safe-smart-account](https://github.com/safe-fndn/safe-smart-account) first.
+- **Your chain must be listed on [ChainList](https://chainlist.org/).** CI fetches the RPC from there automatically.
+- **One chain ID, one Safe version, and one deployment type per PR.** PRs that touch multiple will fail the automated check.
+- **Commits must be signed.** Unsigned commits will be blocked at merge time. See [GitHub's guide on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) if you haven't set this up.
+
+## Adding a new chain
+
+Use the `update-registry` script — it handles JSON structure and chain ID ordering automatically:
+
+```bash
+pnpm update-registry --version v1.5.0 --chainId <CHAIN_ID> --deploymentType canonical
+```
+
+Valid versions: `v1.0.0`, `v1.1.1`, `v1.2.0`, `v1.3.0`, `v1.4.1`, `v1.5.0`  
+Valid deployment types: `canonical`, `eip155`, `zksync`
+
+## Before pushing
+
+```bash
+pnpm install --frozen-lockfile  # Node 22+, pnpm >=10.16.0
+pnpm lint:fix                   # Auto-format JSON files
+pnpm test                       # Run the full test suite
+```
+
+CI will also verify on-chain that every contract address and code hash match the deployed bytecode.
+
+## PR description
+
+Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with the chain ID and any relevant notes (block explorer URL, testnet caveats, etc.).
+
+## Release cadence
+
+Merged PRs are batched into a monthly npm release. The `@safe-global/platform` team reviews all PRs.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,13 @@
 [![npm version](https://badge.fury.io/js/%40safe-global%2Fsafe-deployments.svg)](https://badge.fury.io/js/%40safe-global%2Fsafe-deployments)
 [![CI](https://github.com/safe-global/safe-deployments/actions/workflows/test.yml/badge.svg)](https://github.com/safe-global/safe-deployments/actions/workflows/test.yml)
 
-This contract contains a collection of deployments of the contract of the [Safe contracts repository](https://github.com/safe-global/safe-smart-account).
+This contract contains a collection of deployments of the contract of the [Safe contracts repository](https://github.com/safe-fndn/safe-smart-account).
 
 The addresses on the different networks and the abi files are available for each deployment. To get an overview of the available versions, check the available [json assets](./src/assets/).
 
-## Adding additional deployments:
+## Adding additional deployments
 
-1. Follow the [deployment steps in the Safe contract repository](https://github.com/safe-global/safe-smart-account/#deployments).
-2. Verify that the addresses match the expected address for each contract. You can find them under the "addresses" mapping in the respective JSON file in the [assets folder](./src/assets/).
-3. Create a PR adding the new deployment. Example PR can be found [here](https://github.com/safe-global/safe-deployments/pull/676).
+To register a new chain deployment, read the [contributing guide](CONTRIBUTING.md).
 
 ## Deployments overview
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "lint:fix:json": "prettier -w src/assets/*/*.json",
     "review:verify-deployment": "ts-node scripts/review/verifyDeployment.ts",
     "review:diff": "ts-node scripts/review/diff.ts",
-    "update-registry": "ts-node scripts/update-registry.ts",
-    "postupdate-registry": "pnpm run lint:fix:json",
+    "update-registry": "ts-node scripts/update-registry.ts && pnpm run lint:fix:json",
     "prepack": "pnpm run build",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary

This PR introduces a contributing guide and cleans up several related files that were outdated or inconsistent.

### Changes
**New**: `CONTRIBUTING.md`
Concise guide covering everything a contributor needs: prerequisites (contracts deployed, chain on ChainList, commit signing), the one-PR rules, how to use the `update-registry` script, the correct `eip155`/`canonical` order for v1.3.0, and local checks before pushing.

`README.md`

 - Replaced the outdated 3-step "Adding additional deployments" section with a single link to `CONTRIBUTING.md`.
 - Updated two references from `safe-global/safe-contracts` and `safe-global/safe-smart-account` to the correct `safe-fndn/safe-smart-account`

`.github/PULL_REQUEST_TEMPLATE.md`

 - Updated `safe-global/safe-contracts` link to `safe-fndn/safe-smart-account`
 - Added a link to `CONTRIBUTING.md` so contributors see it in context when opening a PR

`package.json`

 - Inlined `postupdate-registry` hook into `update-registry`. The implicit lifecycle hook wasn't obvious and looked like dead code

`.github/workflows/update-registry.yml`

Fixed `v1.3.0-both` to run `eip155` before `canonical`, so new chains correctly get `["eip155", "canonical"]` instead of `["canonical", "eip155"]`