### PR TITLE
Add Seismic Testnet to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -147,6 +147,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -147,6 +147,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -147,6 +147,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -173,6 +173,7 @@
     "5031": "canonical",
     "5042": "canonical",
     "5115": "canonical",
+    "5124": "canonical",
     "5330": "canonical",
     "5464": "canonical",
     "5611": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 5124

Relevant information:
- Network: Seismic Testnet
- Explorer: https://seismic-testnet.socialscan.io/ (SocialScan)
- Safe version: v1.4.1
- Deployment type: canonical