### PR TITLE
Add Seismic Testnet to v1.3.0 registry (eip155)

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -215,6 +215,7 @@
     "5003": ["eip155", "canonical"],
     "5042": ["eip155", "canonical"],
     "5115": ["eip155", "canonical"],
+    "5124": "eip155",
     "5165": "canonical",
     "5330": ["eip155", "canonical"],
     "5464": ["eip155", "canonical"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 5124

Relevant information:
- Network: Seismic Testnet
- Explorer: https://seismic-testnet.socialscan.io/ (SocialScan)
- Safe version: v1.3.0
- Deployment type: eip155