### PR TITLE
Add Mizuhiki Mainnet to v1.3.0 registry

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -230,6 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
+    "6498": ["canonical", "eip155"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -230,7 +230,7 @@
     "6102": "eip155",
     "6398": "eip155",
     "6497": ["eip155", "canonical"],
-    "6498": ["canonical", "eip155"],
+    "6498": ["eip155", "canonical"],
     "6880": "canonical",
     "6900": ["canonical", "eip155"],
     "6911": ["canonical", "eip155"],


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 6498

Relevant information:
- Network: Mizuhiki Mainnet
- Explorer: pending (Blockscout)
- Safe version: v1.3.0
- Deployment type: canonical + eip155