### PR TITLE
Add Mizuhiki Mainnet to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -164,6 +164,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6900": "canonical",
     "6911": "canonical",
     "6942": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -164,6 +164,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6900": "canonical",
     "6911": "canonical",
     "6942": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -164,6 +164,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6900": "canonical",
     "6911": "canonical",
     "6942": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -191,6 +191,7 @@
     "6342": "canonical",
     "6398": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "6688": "canonical",
     "6900": "canonical",
     "6911": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 6498

Relevant information:
- Network: Mizuhiki Mainnet
- Explorer: pending (Blockscout)
- Safe version: v1.4.1
- Deployment type: canonical