### PR TITLE
Add Mizuhiki Mainnet to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -54,6 +54,7 @@
     "5424": "canonical",
     "5887": "canonical",
     "6497": "canonical",
+    "6498": "canonical",
     "7001": "canonical",
     "7979": "canonical",
     "8150": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 6498

Relevant information:
- Network: Mizuhiki Mainnet
- Explorer: pending (Blockscout)
- Safe version: v1.5.0
- Deployment type: canonical