### PR TITLE
feat: add Shark Network (88118) to v1.5.0 registry

### DIFF
--- a/src/assets/v1.5.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.5.0/compatibility_fallback_handler.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/create_call.json
+++ b/src/assets/v1.5.0/create_call.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/extensible_fallback_handler.json
+++ b/src/assets/v1.5.0/extensible_fallback_handler.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/multi_send.json
+++ b/src/assets/v1.5.0/multi_send.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/multi_send_call_only.json
+++ b/src/assets/v1.5.0/multi_send_call_only.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/safe.json
+++ b/src/assets/v1.5.0/safe.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/safe_l2.json
+++ b/src/assets/v1.5.0/safe_l2.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/safe_migration.json
+++ b/src/assets/v1.5.0/safe_migration.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/safe_proxy_factory.json
+++ b/src/assets/v1.5.0/safe_proxy_factory.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/safe_to_l2_setup.json
+++ b/src/assets/v1.5.0/safe_to_l2_setup.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/sign_message_lib.json
+++ b/src/assets/v1.5.0/sign_message_lib.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/simulate_tx_accessor.json
+++ b/src/assets/v1.5.0/simulate_tx_accessor.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",

--- a/src/assets/v1.5.0/token_callback_handler.json
+++ b/src/assets/v1.5.0/token_callback_handler.json
@@ -71,6 +71,7 @@
     "49088": "canonical",
     "59141": "canonical",
     "80069": "canonical",
+    "88118": "canonical",
     "88811": "canonical",
     "88817": "canonical",
     "102030": "canonical",


### PR DESCRIPTION
Chain ID: 88118
Relevant information:

Network Name: Shark Network
RPC URL: https://rpc.rpcshark.com/
Explorer URL: https://sharkscan.app/
Native Currency: SHARK (18 decimals )
This PR adds support for Shark Network (chainId 88118) to the Safe deployments registry. The contracts are assumed to be deployed on the chain, and the RPC is taken from ChainList.org. This PR only includes changes for chainId 88118, Safe version v1.5.0, and deployment type 'canonical'.
