### PR TITLE
fix: update-registry to pass parameters to script

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -93,6 +93,9 @@ jobs:
               --verbose
           fi
 
+      - name: Format updated registry files
+        run: pnpm run update-registry:lint
+
       - name: Check for changes
         id: check-changes
         run: |

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint:fix:json": "prettier -w src/assets/*/*.json",
     "review:verify-deployment": "ts-node scripts/review/verifyDeployment.ts",
     "review:diff": "ts-node scripts/review/diff.ts",
-    "update-registry": "ts-node scripts/update-registry.ts && pnpm run lint:fix:json",
+    "update-registry": "ts-node scripts/update-registry.ts",
+    "update-registry:lint": "pnpm run lint:fix:json",
     "prepack": "pnpm run build",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary

Avoid lint call consuming parameters targeting update-registry script
