### PR TITLE
Add Humanity chain (13600000) to v1.4.1 registry

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -331,6 +331,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -331,6 +331,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -331,6 +331,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -388,6 +388,7 @@
     "11155931": "canonical",
     "12227332": "canonical",
     "13374202": "canonical",
+    "13600000": "canonical",
     "13863860": "canonical",
     "20250407": "canonical",
     "21000000": "canonical",


### PR DESCRIPTION
Canonical deployments for the relaunched Humanity Protocol mainnet (chainId **13600000**), deployed via the Safe singleton factory (`artifacts/13600000` merged on Aug 4 — safe-fndn/safe-singleton-factory#1437).

- All **12 v1.4.1 contracts** deployed at the canonical addresses; bytecode verified byte-identical to Ethereum mainnet for every one of them
- Chain is listed on [chainlist.org](https://chainlist.org/chain/13600000) (RPC: `https://humanity-main.g.alchemy.com/public`, batch requests supported)
- Entries generated with `pnpm update-registry --version v1.4.1 --chainId 13600000` + `update-registry:lint`; full test suite passes locally
- Same registration scope as the previous Humanity chain (6985385, added in #1250), which is now deprecated in favor of this relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)