### PR TITLE
Add NetX Mainnet (287) Safe v1.4.1 deployment

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -53,6 +53,7 @@
     "240": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -53,6 +53,7 @@
     "240": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -53,6 +53,7 @@
     "240": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -64,6 +64,7 @@
     "250": "canonical",
     "252": "canonical",
     "255": "canonical",
+    "287": "canonical",
     "288": "canonical",
     "300": ["zksync", "canonical"],
     "314": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 287

Relevant information:
- Network: NetX Mainnet
- Safe version: v1.4.1
- Deployment type: canonical
- Block explorer: https://netxscan.io
- RPC: https://rpc.netxscan.io
- Contracts were deployed and verified on-chain using the canonical Safe addresses.