### PR TITLE
Add NetX Testnet (587) Safe v1.4.1 deployment

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/safe_migration.json
+++ b/src/assets/v1.4.1/safe_migration.json
@@ -64,6 +64,7 @@
     "478": "canonical",
     "480": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_migration.json
+++ b/src/assets/v1.4.1/safe_to_l2_migration.json
@@ -64,6 +64,7 @@
     "478": "canonical",
     "480": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/safe_to_l2_setup.json
+++ b/src/assets/v1.4.1/safe_to_l2_setup.json
@@ -64,6 +64,7 @@
     "478": "canonical",
     "480": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -77,6 +77,7 @@
     "480": "canonical",
     "530": "canonical",
     "545": "canonical",
+    "587": "canonical",
     "592": "canonical",
     "677": "canonical",
     "690": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 587

Relevant information:
- Network: NetX Testnet
- Safe version: v1.4.1
- Deployment type: canonical
- Block explorer: https://testnet.netxscan.io
- RPC: https://testnetrpc.netxscan.io
- Contracts were deployed and verified on-chain using the canonical Safe addresses.