### PR TITLE
Add Shibarium (109) canonical deployment for v1.4.1

### DIFF
--- a/src/assets/v1.4.1/compatibility_fallback_handler.json
+++ b/src/assets/v1.4.1/compatibility_fallback_handler.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/create_call.json
+++ b/src/assets/v1.4.1/create_call.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/multi_send.json
+++ b/src/assets/v1.4.1/multi_send.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/multi_send_call_only.json
+++ b/src/assets/v1.4.1/multi_send_call_only.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/safe.json
+++ b/src/assets/v1.4.1/safe.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/safe_l2.json
+++ b/src/assets/v1.4.1/safe_l2.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/safe_proxy_factory.json
+++ b/src/assets/v1.4.1/safe_proxy_factory.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/sign_message_lib.json
+++ b/src/assets/v1.4.1/sign_message_lib.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",

--- a/src/assets/v1.4.1/simulate_tx_accessor.json
+++ b/src/assets/v1.4.1/simulate_tx_accessor.json
@@ -39,6 +39,7 @@
     "98": "canonical",
     "100": "canonical",
     "106": "canonical",
+    "109": "canonical",
     "114": "canonical",
     "122": "canonical",
     "130": "canonical",


### PR DESCRIPTION
# Add Shibarium (chain 109) — Safe v1.4.1 canonical deployment

All nine Safe v1.4.1 contracts are now deployed on Shibarium mainnet at their
canonical addresses via the Safe Singleton Factory
(`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`), and verified on the chain's
block explorer.

Shibarium already has v1.3.0 registered here via the `eip155` deployment set.
This PR adds v1.4.1 at the **canonical** addresses, which means the
SafeProxyFactory is at the same address as on every other canonical chain, so
Safes created on Shibarium share addresses with their counterparts on other
networks. The existing v1.3.0 `eip155` factory cannot provide that.

## Network

| | |
|---|---|
| Name | Shibarium |
| Chain ID | 109 |
| Currency | BONE |
| RPC | https://rpc.shibarium.shib.io |
| Explorer | https://shibariumscan.io |

## Deployed contracts

Every address matches `deployments.canonical.address`, and each on-chain runtime
`keccak256(code)` matches the `deployments.canonical.codeHash` published in this
repository. Bytecode is byte-for-byte identical to the Ethereum mainnet
deployments.

| Contract | Address |
|---|---|
| SafeL2 | `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762` |
| Safe | `0x41675C099F32341bf84BFc5382aF534df5C7461a` |
| SafeProxyFactory | `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67` |
| CompatibilityFallbackHandler | `0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99` |
| MultiSend | `0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526` |
| MultiSendCallOnly | `0x9641d764fc13c8B624c04430C7356C1C7C8102e2` |
| SignMessageLib | `0xd53cd0aB83D845Ac265BE939c57F53AD838012c9` |
| CreateCall | `0x9b35Af71d77eaf8d7e40252370304687390A1A52` |
| SimulateTxAccessor | `0x3d4BA2E0884aa488718476ca2FB8Efc291A46199` |

All nine are source-verified on https://shibariumscan.io.

## Checks performed

- `Safe.VERSION()` and `SafeL2.VERSION()` both return `1.4.1`
- `SafeProxyFactory.proxyCreationCode()` returns 486 bytes identical to the
  Ethereum mainnet factory
- Each contract's runtime `codeHash` matches the value in this repository
