### PR TITLE
Add XGR Mainnet (1643) to Safe v1.3.0 deployments

### DIFF
--- a/src/assets/v1.3.0/compatibility_fallback_handler.json
+++ b/src/assets/v1.3.0/compatibility_fallback_handler.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/create_call.json
+++ b/src/assets/v1.3.0/create_call.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe.json
+++ b/src/assets/v1.3.0/gnosis_safe.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/gnosis_safe_l2.json
+++ b/src/assets/v1.3.0/gnosis_safe_l2.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/multi_send.json
+++ b/src/assets/v1.3.0/multi_send.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/multi_send_call_only.json
+++ b/src/assets/v1.3.0/multi_send_call_only.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/proxy_factory.json
+++ b/src/assets/v1.3.0/proxy_factory.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/sign_message_lib.json
+++ b/src/assets/v1.3.0/sign_message_lib.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",

--- a/src/assets/v1.3.0/simulate_tx_accessor.json
+++ b/src/assets/v1.3.0/simulate_tx_accessor.json
@@ -152,6 +152,7 @@
     "1516": ["eip155", "canonical"],
     "1559": "eip155",
     "1625": ["eip155", "canonical"],
+    "1643": "eip155",
     "1663": "eip155",
     "1672": ["eip155", "canonical"],
     "1729": "canonical",


### PR DESCRIPTION
## Add new chain

Please fill the following form:

Provide the Chain ID (Only 1 chain id per PR).
- Chain_ID: 1643

Relevant information:
- Network: XGR Mainnet
- Safe version: v1.3.0
- Deployment type: eip155
- Contracts deployed at the expected deterministic addresses
- 168/168 repository tests passed
- Block explorer: https://explorer.xgr.network